### PR TITLE
Rename Clay_Rectangle to Clay_BoundingBox to prevent confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1462,7 +1462,7 @@ An array of [Clay_RenderCommand](#clay_rendercommand)s representing the calculat
 ```C
 typedef struct
 {
-    Clay_Rectangle boundingBox;
+    Clay_BoundingBox boundingBox;
     Clay_ElementConfigUnion config;
     Clay_String text;
     uint32_t id;
@@ -1487,12 +1487,12 @@ An enum indicating how this render command should be handled. Possible values in
 
 ---
 
-**`.boundingBox`** - `Clay_Rectangle`
+**`.boundingBox`** - `Clay_BoundingBox`
 
 ```C
 typedef struct {
     float x, y, width, height;
-} Clay_Rectangle;
+} Clay_BoundingBox;
 ```
 
 A rectangle representing the bounding box of this render command, with `.x` and `.y` representing the top left corner of the element.

--- a/clay.h
+++ b/clay.h
@@ -242,7 +242,7 @@ typedef struct {
 
 typedef struct {
     float x, y, width, height;
-} Clay_Rectangle;
+} Clay_BoundingBox;
 
 typedef struct {
     float width, height;
@@ -727,7 +727,7 @@ Clay_LayoutElement* Clay__LayoutElementPointerArray_RemoveSwapback(Clay__LayoutE
 
 typedef struct
 {
-    Clay_Rectangle boundingBox;
+    Clay_BoundingBox boundingBox;
     Clay_ElementConfigUnion config;
     Clay_String text; // TODO I wish there was a way to avoid having to have this on every render command
     uint32_t id;
@@ -774,7 +774,7 @@ Clay_RenderCommand *Clay_RenderCommandArray_Get(Clay_RenderCommandArray *array, 
 typedef struct
 {
     Clay_LayoutElement *layoutElement;
-    Clay_Rectangle boundingBox;
+    Clay_BoundingBox boundingBox;
     Clay_Dimensions contentSize;
     Clay_Vector2 scrollOrigin;
     Clay_Vector2 pointerOrigin;
@@ -830,7 +830,7 @@ Clay__ScrollContainerDataInternal Clay__ScrollContainerDataInternalArray_RemoveS
 
 typedef struct
 {
-    Clay_Rectangle boundingBox;
+    Clay_BoundingBox boundingBox;
     uint32_t id;
     Clay_LayoutElement* layoutElement;
     int32_t nextIndex;
@@ -1157,7 +1157,7 @@ Clay_Dimensions Clay__MeasureTextCached(Clay_String *text, Clay_TextElementConfi
     return measured;
 }
 
-bool Clay__PointIsInsideRect(Clay_Vector2 point, Clay_Rectangle rect) {
+bool Clay__PointIsInsideRect(Clay_Vector2 point, Clay_BoundingBox rect) {
     return point.x >= rect.x && point.x <= rect.x + rect.width && point.y >= rect.y && point.y <= rect.y + rect.height;
 }
 
@@ -1776,7 +1776,7 @@ void Clay__CalculateFinalLayout(int screenWidth, int screenHeight) {
         if (parentHashMapItem) {
             Clay_FloatingElementConfig *config = root->layoutElement->elementConfig.floatingElementConfig;
             Clay_Dimensions rootDimensions = root->layoutElement->dimensions;
-            Clay_Rectangle parentBoundingBox = parentHashMapItem->boundingBox;
+            Clay_BoundingBox parentBoundingBox = parentHashMapItem->boundingBox;
             // Set X position
             Clay_Vector2 targetAttachPosition = (Clay_Vector2){};
             switch (config->attachment.parent) {
@@ -1850,7 +1850,7 @@ void Clay__CalculateFinalLayout(int screenWidth, int screenHeight) {
             if (!Clay__treeNodeVisited.internalArray[dfsBuffer.length - 1]) {
                 Clay__treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
 
-                Clay_Rectangle currentElementBoundingBox = (Clay_Rectangle) { currentElementTreeNode->position.x, currentElementTreeNode->position.y, currentElement->dimensions.width, currentElement->dimensions.height };
+                Clay_BoundingBox currentElementBoundingBox = (Clay_BoundingBox) { currentElementTreeNode->position.x, currentElementTreeNode->position.y, currentElement->dimensions.width, currentElement->dimensions.height };
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_FLOATING_CONTAINER) {
                     Clay_FloatingElementConfig *floatingElementConfig = currentElement->elementConfig.floatingElementConfig;
                     Clay_Dimensions expand = floatingElementConfig->expand;
@@ -1975,7 +1975,7 @@ void Clay__CalculateFinalLayout(int screenWidth, int screenHeight) {
                     });
                 // Borders between elements are expressed as additional rectangle render commands
                 } else if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_BORDER_CONTAINER) {
-                    Clay_Rectangle currentElementBoundingBox = (Clay_Rectangle) { currentElementTreeNode->position.x, currentElementTreeNode->position.y, currentElement->dimensions.width, currentElement->dimensions.height };
+                    Clay_BoundingBox currentElementBoundingBox = (Clay_BoundingBox) { currentElementTreeNode->position.x, currentElementTreeNode->position.y, currentElement->dimensions.width, currentElement->dimensions.height };
                     bool offscreen = currentElementBoundingBox.x > (float)screenWidth || currentElementBoundingBox.y > (float)screenHeight || currentElementBoundingBox.x + currentElementBoundingBox.width < 0 || currentElementBoundingBox.y + currentElementBoundingBox.height < 0;
                     if (offscreen) {
                         dfsBuffer.length--;
@@ -2122,7 +2122,7 @@ void Clay_SetPointerPosition(Clay_Vector2 position) {
             Clay__treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
             Clay_LayoutElement *currentElement = *Clay__LayoutElementPointerArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1);
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
-            if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, (Clay_Rectangle) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
+            if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, (Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
                 Clay__int32_tArray_Add(&Clay__pointerOverIds, (int)currentElement->id);
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {
                     dfsBuffer.length--;

--- a/renderers/raylib/clay_renderer_raylib.c
+++ b/renderers/raylib/clay_renderer_raylib.c
@@ -135,7 +135,7 @@ void Clay_Raylib_Render(Clay_RenderCommandArray renderCommands)
     for (int j = 0; j < renderCommands.length; j++)
     {
         Clay_RenderCommand *renderCommand = Clay_RenderCommandArray_Get(&renderCommands, j);
-        Clay_Rectangle boundingBox = renderCommand->boundingBox;
+        Clay_BoundingBox boundingBox = renderCommand->boundingBox;
         switch (renderCommand->commandType)
         {
             case CLAY_RENDER_COMMAND_TYPE_TEXT: {
@@ -214,7 +214,7 @@ void Clay_Raylib_Render(Clay_RenderCommandArray renderCommands)
                 if (!customElement) continue;
                 switch (customElement->type) {
                     case CUSTOM_LAYOUT_ELEMENT_TYPE_3D_MODEL: {
-                        Clay_Rectangle rootBox = renderCommands.internalArray[0].boundingBox;
+                        Clay_BoundingBox rootBox = renderCommands.internalArray[0].boundingBox;
                         float scaleValue = CLAY__MIN(CLAY__MIN(1, 768 / rootBox.height) * CLAY__MAX(1, rootBox.width / 1024), 1.5f);
                         Ray positionRay = GetScreenToWorldPointWithZDistance((Vector2) { renderCommand->boundingBox.x + renderCommand->boundingBox.width / 2, renderCommand->boundingBox.y + (renderCommand->boundingBox.height / 2) + 20 }, Raylib_camera, (int)roundf(rootBox.width), (int)roundf(rootBox.height), 140);
                         BeginMode3D(Raylib_camera);


### PR DESCRIPTION
I made what I believe to be a mistake in naming the internal {x, y, width, height} struct `Clay_Rectangle`.

Unfortunately this is a breaking change if you are referencing the struct by name, but there's too much of an overlap / confusion with the element macro `CLAY_RECTANGLE`, and I would like there to be a clear mental model of "rectangle means the element", so I've renamed the struct to `Clay_BoundingBox`, which is more in line with how it is referred to in render commands anyway.