### PR TITLE
[bindings/odin] Fix memory leak in Odin example

### DIFF
--- a/bindings/odin/examples/clay-official-website/clay-official-website.odin
+++ b/bindings/odin/examples/clay-official-website/clay-official-website.odin
@@ -538,6 +538,8 @@ main :: proc() {
     checkImage5 = raylib.LoadTextureFromImage(raylib.LoadImage("resources/check_5.png"))
 
     for !raylib.WindowShouldClose() {
+        defer free_all(context.temp_allocator)
+        
         animationLerpValue += raylib.GetFrameTime()
         if animationLerpValue > 1 {
             animationLerpValue = animationLerpValue - 2


### PR DESCRIPTION
Should fix an apparent memory leak (you allocate a clone of the text in the raylib renderer, however the temp_allocator was never freed)