### PR TITLE
Use shallow clone on Raylib

### DIFF
--- a/examples/raylib-sidebar-scrolling-container/CMakeLists.txt
+++ b/examples/raylib-sidebar-scrolling-container/CMakeLists.txt
@@ -12,6 +12,7 @@ FetchContent_Declare(
     GIT_REPOSITORY "https://github.com/raysan5/raylib.git"
     GIT_TAG "master"
     GIT_PROGRESS TRUE
+    GIT_SHALLOW TRUE
 )
 
 FetchContent_MakeAvailable(raylib)


### PR DESCRIPTION
This change reduces the time of project configuration.

On my machine with decent internet connection, I got these results:
Without shallow clone: `cmake ..  24.75s user 6.55s system 54% cpu 57.140 total`
With shallow clone: `cmake ..  12.41s user 4.48s system 39% cpu 42.758 total`

Thank you for your time and effort!