### PR TITLE
Fix const inits and add docker tests for gcc 9.4 

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1307,7 +1307,7 @@ typedef struct
 
 Clay__PointerInfo Clay__pointerInfo = (Clay__PointerInfo) { -1, -1 };
 Clay_Dimensions Clay__layoutDimensions = (Clay_Dimensions){};
-Clay_ElementId Clay__dynamicElementIndexBaseHash = (Clay_ElementId) { .id = 128476991, .stringId = CLAY_STRING("Auto ID") };
+Clay_ElementId Clay__dynamicElementIndexBaseHash = (Clay_ElementId) { .id = 128476991, .stringId = { .chars = "Auto ID", .length = 8 } };
 uint32_t Clay__dynamicElementIndex = 0;
 bool Clay__debugModeEnabled = false;
 uint32_t Clay__debugSelectedElementId = 0;
@@ -2440,15 +2440,15 @@ inline Clay_ScrollElementConfig * Clay__StoreScrollElementConfig(Clay_ScrollElem
 inline Clay_BorderElementConfig * Clay__StoreBorderElementConfig(Clay_BorderElementConfig config) { return Clay__BorderElementConfigArray_Add(&Clay__borderElementConfigs, config); }
 
 #pragma region DebugTools
-#define CLAY__DEBUGVIEW_COLOR_1 (Clay_Color) {58, 56, 52, 255}
-#define CLAY__DEBUGVIEW_COLOR_2 (Clay_Color) {62, 60, 58, 255}
-#define CLAY__DEBUGVIEW_COLOR_3 (Clay_Color) {141, 133, 135, 255}
-#define CLAY__DEBUGVIEW_COLOR_4 (Clay_Color) {238, 226, 231, 255}
-#define CLAY__DEBUGVIEW_COLOR_SELECTED_ROW (Clay_Color) {102, 80, 78, 255}
+Clay_Color CLAY__DEBUGVIEW_COLOR_1 = (Clay_Color) {58, 56, 52, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_2 = (Clay_Color) {62, 60, 58, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_3 = (Clay_Color) {141, 133, 135, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_4 = (Clay_Color) {238, 226, 231, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_SELECTED_ROW = (Clay_Color) {102, 80, 78, 255};
 const int CLAY__DEBUGVIEW_ROW_HEIGHT = 30;
 const int CLAY__DEBUGVIEW_OUTER_PADDING = 10;
 const int CLAY__DEBUGVIEW_INDENT_WIDTH = 16;
-Clay_TextElementConfig Clay__DebugView_TextNameConfig = (Clay_TextElementConfig) {.fontSize = 16, .textColor = CLAY__DEBUGVIEW_COLOR_4, .wrapMode = CLAY_TEXT_WRAP_NONE };
+Clay_TextElementConfig Clay__DebugView_TextNameConfig = (Clay_TextElementConfig) {.fontSize = 16, .textColor = {238, 226, 231, 255}, .wrapMode = CLAY_TEXT_WRAP_NONE };
 Clay_LayoutConfig Clay__DebugView_ScrollViewItemLayoutConfig = (Clay_LayoutConfig) {};
 
 Clay_String Clay__IntToString(int integer) {

--- a/examples/clay-official-website/main.c
+++ b/examples/clay-official-website/main.c
@@ -16,33 +16,29 @@ const uint32_t FONT_ID_TITLE_36 = 4;
 const uint32_t FONT_ID_MONOSPACE_24 = 5;
 
 const Clay_Color COLOR_LIGHT = (Clay_Color) {244, 235, 230, 255};
-Clay_Color COLOR_LIGHT_HOVER = (Clay_Color) {224, 215, 210, 255};
-Clay_Color COLOR_BUTTON_HOVER = (Clay_Color) {238, 227, 225, 255};
-Clay_Color COLOR_BROWN = (Clay_Color) {61, 26, 5, 255};
-Clay_Color COLOR_RED = (Clay_Color) {168, 66, 28, 255};
-Clay_Color COLOR_RED_HOVER = (Clay_Color) {148, 46, 8, 255};
-Clay_Color COLOR_ORANGE = (Clay_Color) {225, 138, 50, 255};
-Clay_Color COLOR_BLUE = (Clay_Color) {111, 173, 162, 255};
-Clay_Color COLOR_TEAL = (Clay_Color) {111, 173, 162, 255};
-Clay_Color COLOR_BLUE_DARK = (Clay_Color) {2, 32, 82, 255};
+const Clay_Color COLOR_LIGHT_HOVER = (Clay_Color) {224, 215, 210, 255};
+const Clay_Color COLOR_RED = (Clay_Color) {168, 66, 28, 255};
+const Clay_Color COLOR_RED_HOVER = (Clay_Color) {148, 46, 8, 255};
+const Clay_Color COLOR_ORANGE = (Clay_Color) {225, 138, 50, 255};
+const Clay_Color COLOR_BLUE = (Clay_Color) {111, 173, 162, 255};
 
 // Colors for top stripe
-Clay_Color COLOR_TOP_BORDER_1 = (Clay_Color) {168, 66, 28, 255};
-Clay_Color COLOR_TOP_BORDER_2 = (Clay_Color) {223, 110, 44, 255};
-Clay_Color COLOR_TOP_BORDER_3 = (Clay_Color) {225, 138, 50, 255};
-Clay_Color COLOR_TOP_BORDER_4 = (Clay_Color) {236, 189, 80, 255};
-Clay_Color COLOR_TOP_BORDER_5 = (Clay_Color) {240, 213, 137, 255};
+const Clay_Color COLOR_TOP_BORDER_1 = (Clay_Color) {168, 66, 28, 255};
+const Clay_Color COLOR_TOP_BORDER_2 = (Clay_Color) {223, 110, 44, 255};
+const Clay_Color COLOR_TOP_BORDER_3 = (Clay_Color) {225, 138, 50, 255};
+const Clay_Color COLOR_TOP_BORDER_4 = (Clay_Color) {236, 189, 80, 255};
+const Clay_Color COLOR_TOP_BORDER_5 = (Clay_Color) {240, 213, 137, 255};
 
-Clay_Color COLOR_BLOB_BORDER_1 = (Clay_Color) {168, 66, 28, 255};
-Clay_Color COLOR_BLOB_BORDER_2 = (Clay_Color) {203, 100, 44, 255};
-Clay_Color COLOR_BLOB_BORDER_3 = (Clay_Color) {225, 138, 50, 255};
-Clay_Color COLOR_BLOB_BORDER_4 = (Clay_Color) {236, 159, 70, 255};
-Clay_Color COLOR_BLOB_BORDER_5 = (Clay_Color) {240, 189, 100, 255};
+const Clay_Color COLOR_BLOB_BORDER_1 = (Clay_Color) {168, 66, 28, 255};
+const Clay_Color COLOR_BLOB_BORDER_2 = (Clay_Color) {203, 100, 44, 255};
+const Clay_Color COLOR_BLOB_BORDER_3 = (Clay_Color) {225, 138, 50, 255};
+const Clay_Color COLOR_BLOB_BORDER_4 = (Clay_Color) {236, 159, 70, 255};
+const Clay_Color COLOR_BLOB_BORDER_5 = (Clay_Color) {240, 189, 100, 255};
 
 #define RAYLIB_VECTOR2_TO_CLAY_VECTOR2(vector) (Clay_Vector2) { .x = vector.x, .y = vector.y }
 
-Clay_TextElementConfig headerTextConfig = (Clay_TextElementConfig) { .fontId = FONT_ID_BODY_24, .fontSize = 24, .textColor = {61, 26, 5, 255} };
-Clay_TextElementConfig blobTextConfig = (Clay_TextElementConfig) { .fontId = FONT_ID_BODY_24, .fontSize = 30, .textColor = COLOR_LIGHT };
+Clay_TextElementConfig headerTextConfig = (Clay_TextElementConfig) { .fontId = 2, .fontSize = 24, .textColor = {61, 26, 5, 255} };
+Clay_TextElementConfig blobTextConfig = (Clay_TextElementConfig) { .fontId = 2, .fontSize = 30, .textColor = {244, 235, 230, 255} };
 
 void LandingPageBlob(int index, int fontSize, Clay_Color color, Clay_String text, Clay_String imageURL) {
     CLAY_BORDER_CONTAINER(CLAY_IDI("HeroBlob", index), CLAY_LAYOUT(.sizing = { CLAY_SIZING_GROW(.max = 480) }, .padding = {16, 16}, .childGap = 16, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER}), CLAY_BORDER_CONFIG_OUTSIDE_RADIUS(2, color, 10), {

--- a/examples/raylib-sidebar-scrolling-container/main.c
+++ b/examples/raylib-sidebar-scrolling-container/main.c
@@ -4,14 +4,14 @@
 
 const uint32_t FONT_ID_BODY_24 = 0;
 const uint32_t FONT_ID_BODY_16 = 1;
-Clay_Color COLOR_ORANGE = (Clay_Color) {225, 138, 50, 255};
-Clay_Color COLOR_BLUE = (Clay_Color) {111, 173, 162, 255};
+#define COLOR_ORANGE (Clay_Color) {225, 138, 50, 255}
+#define COLOR_BLUE (Clay_Color) {111, 173, 162, 255}
 
 Texture2D profilePicture;
 #define RAYLIB_VECTOR2_TO_CLAY_VECTOR2(vector) (Clay_Vector2) { .x = vector.x, .y = vector.y }
 
 Clay_String profileText = CLAY_STRING("Profile Page one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen");
-Clay_TextElementConfig headerTextConfig = (Clay_TextElementConfig) { .fontId = FONT_ID_BODY_16, .fontSize = 16, .textColor = {0,0,0,255} };
+Clay_TextElementConfig headerTextConfig = (Clay_TextElementConfig) { .fontId = 1, .fontSize = 16, .textColor = {0,0,0,255} };
 
 // Examples of re-usable "Components"
 void RenderHeaderButton(uint16_t index, Clay_String text) {

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  gcc:
+    build:
+      context: ../
+      dockerfile: tests/gcc/9.4/Dockerfile
+    volumes:
+      - /tmp/clay/_deps

--- a/tests/gcc/9.4/Dockerfile
+++ b/tests/gcc/9.4/Dockerfile
@@ -1,0 +1,19 @@
+FROM --platform=linux/amd64 ubuntu:20.04
+
+RUN apt update -y
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential
+RUN DEBIAN_FRONTEND=noninteractive apt install -y wget
+WORKDIR /tmp/
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz
+RUN tar zxvf cmake-3.28.4-linux-x86_64.tar.gz
+RUN DEBIAN_FRONTEND=noninteractive apt install -y git
+RUN DEBIAN_FRONTEND=noninteractive apt install -y libwayland-dev
+RUN DEBIAN_FRONTEND=noninteractive apt install -y pkg-config
+RUN DEBIAN_FRONTEND=noninteractive apt install -y libxkbcommon-dev
+RUN DEBIAN_FRONTEND=noninteractive apt install -y xorg-dev
+
+ADD . /tmp/clay
+
+WORKDIR /tmp/clay
+
+CMD /tmp/cmake-3.28.4-linux-x86_64/bin/cmake . && /tmp/cmake-3.28.4-linux-x86_64/bin/cmake --build .

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,1 @@
+docker compose build && docker compose up && echo "Tests complete."


### PR DESCRIPTION
Older versions of GCC have quite strict rules around constant initializers, as raised in https://github.com/nicbarker/clay/issues/24. This PR fixes the issues for gcc 9.4 and adds a dockerised test for gcc 9.4 on ubuntu 20.4.