### PR TITLE
Fix of a crash when mapItem is null

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3093,7 +3093,7 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
             if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, CLAY__INIT(Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
             	if (mapItem) {
-            		Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
+                    Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
              	}
 
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {

--- a/clay.h
+++ b/clay.h
@@ -3092,7 +3092,10 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             Clay_LayoutElement *currentElement = Clay_LayoutElementArray_Get(&Clay__layoutElements, Clay__int32_tArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1));
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
             if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, CLAY__INIT(Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
-                Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
+            	if (mapItem) {
+            		Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
+             	}
+
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {
                     dfsBuffer.length--;
                     continue;

--- a/clay.h
+++ b/clay.h
@@ -3091,10 +3091,8 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             Clay__treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
             Clay_LayoutElement *currentElement = Clay_LayoutElementArray_Get(&Clay__layoutElements, Clay__int32_tArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1));
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
-            if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, CLAY__INIT(Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
-            	if (mapItem) {
-                    Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
-             	}
+            if (mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) {
+                Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
 
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {
                     dfsBuffer.length--;


### PR DESCRIPTION
In some situations `mapItem` in `Clay_SetPointerState` can end up being null which results in to crash (because `elementId` is being accessed on null `mapItem`).

An example of this behaviour can be seen when you have an empty layout with only one text:
```c
Clay_BeginLayout();

CLAY_TEXT(
    CLAY_ID("HelloWorldText"), 
    CLAY_STRING("Hello World!"),
    CLAY_TEXT_CONFIG(
        .fontId = FONT_ID_BODY_24, 
        .fontSize = 24,
         .textColor = {255, 0, 0, 255}
    )
);
                             
return Clay_EndLayout();
```