### PR TITLE
[Bug] Fix of broken text NEWLINES wrap mode

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3093,7 +3093,7 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
             if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, CLAY__INIT(Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
             	if (mapItem) {
-            		Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
+                    Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
              	}
 
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {

--- a/clay.h
+++ b/clay.h
@@ -1968,7 +1968,7 @@ void Clay__CalculateFinalLayout() {
             .length = 0,
         };
         // Short circuit all wrap calculations if wrap mode is none
-        if (textConfig->wrapMode == CLAY_TEXT_WRAP_NONE || (containerElement->dimensions.width == textElementData->preferredDimensions.width)) {
+        if (textConfig->wrapMode == CLAY_TEXT_WRAP_NONE || (containerElement->dimensions.width == textElementData->preferredDimensions.width && textConfig->wrapMode != CLAY_TEXT_WRAP_NEWLINES)) {
             Clay_LayoutElementArray_Add(&Clay__layoutElements, CLAY__INIT(Clay_LayoutElement) {
                 .text = text,
                 .dimensions = textElementData->preferredDimensions,

--- a/clay.h
+++ b/clay.h
@@ -3092,7 +3092,10 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             Clay_LayoutElement *currentElement = Clay_LayoutElementArray_Get(&Clay__layoutElements, Clay__int32_tArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1));
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
             if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, CLAY__INIT(Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
-                Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
+            	if (mapItem) {
+            		Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
+             	}
+
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {
                     dfsBuffer.length--;
                     continue;

--- a/clay.h
+++ b/clay.h
@@ -3091,10 +3091,8 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             Clay__treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
             Clay_LayoutElement *currentElement = Clay_LayoutElementArray_Get(&Clay__layoutElements, Clay__int32_tArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1));
             Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO I wish there was a way around this, maybe the fact that it's essentially a binary tree limits the cost, have to measure
-            if ((mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) || (!mapItem && Clay__PointIsInsideRect(position, CLAY__INIT(Clay_BoundingBox) {0,0, currentElement->dimensions.width, currentElement->dimensions.height}))) {
-            	if (mapItem) {
-                    Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
-             	}
+            if (mapItem && Clay__PointIsInsideRect(position, mapItem->boundingBox)) {
+                Clay__ElementIdArray_Add(&Clay__pointerOverIds, mapItem->elementId);
 
                 if (currentElement->elementType == CLAY__LAYOUT_ELEMENT_TYPE_TEXT) {
                     dfsBuffer.length--;


### PR DESCRIPTION
Wrap mode `NEWLINES` was skipped all the time because of this if condition: 
```c
// Short circuit all wrap calculations if wrap mode is none
if (textConfig->wrapMode == CLAY_TEXT_WRAP_NONE || (containerElement->dimensions.width == textElementData->preferredDimensions.width)) {
```
The second part of the if was always true for text with wrapping mode `NEWLINES`. I added another condition that skips this width check in the case of `NEWLINES`.

Automatic word wrapping (works fine):
![image](https://github.com/user-attachments/assets/3a1b5d23-58e3-4242-a072-c7c0491baf0b)

Manual line breaks (`\n`) before the fix:
![image](https://github.com/user-attachments/assets/95e08711-2f1a-447c-90ed-9ffe8ec07640)

Manual line breaks (`\n`) after the fix:
![image](https://github.com/user-attachments/assets/7094ad3e-1818-4879-9d53-63ee8525872c)
