### PR TITLE
Fix scroll on mouse down being overriden by touch scroll

### DIFF
--- a/examples/raylib-sidebar-scrolling-container/main.c
+++ b/examples/raylib-sidebar-scrolling-container/main.c
@@ -141,7 +141,7 @@ void UpdateDrawFrame(void)
     //----------------------------------------------------------------------------------
     // Handle scroll containers
     Clay_Vector2 mousePosition = RAYLIB_VECTOR2_TO_CLAY_VECTOR2(GetMousePosition());
-    Clay_SetPointerState(mousePosition, IsMouseButtonDown(0));
+    Clay_SetPointerState(mousePosition, IsMouseButtonDown(0) && !scrollbarData.mouseDown);
     Clay_SetLayoutDimensions((Clay_Dimensions) { (float)GetScreenWidth(), (float)GetScreenHeight() });
     if (!IsMouseButtonDown(0)) {
         scrollbarData.mouseDown = false;


### PR DESCRIPTION
Fixes unexpected behavior when clicking on scrollbar with mouse, the view would scroll the opposite direction as it would with touch scroll.

This behavior is unexpected with mouse.

The bug was probably caused by Clay_SetPointerState overriding scrollbarData and using the pointer state as scroll information for the container behind the scrollbar instead using the scrollbarData.

This fixes that behavior by not passing mouse down, when mouse down is captured by scrollbar.