### PR TITLE
Forward declare Clay__OpenTextElement

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -464,6 +464,7 @@ Clay_ScrollElementConfig * Clay__StoreScrollElementConfig(Clay_ScrollElementConf
 Clay_BorderElementConfig * Clay__StoreBorderElementConfig(Clay_BorderElementConfig config);
 Clay_ElementId Clay__HashString(Clay_String key, uint32_t offset, uint32_t seed);
 void Clay__Noop();
+void Clay__OpenTextElement(Clay_String text, Clay_TextElementConfig *textConfig);
 
 extern Clay_Color Clay__debugViewHighlightColor;
 extern uint32_t Clay__debugViewWidth;


### PR DESCRIPTION
`CLAY_TEXT` won't work without this.