### PR TITLE
Improve overflow handling / CLAY_MAX_ELEMENT_COUNT exceeded

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3405,6 +3405,9 @@ void Clay_SetLayoutDimensions(Clay_Dimensions dimensions) {
 
 CLAY_WASM_EXPORT("Clay_SetPointerState")
 void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
+    if (Clay__debugMaxElementsLatch) {
+        return;
+    }
     Clay__pointerInfo.position = position;
     Clay__pointerOverIds.length = 0;
     Clay__int32_tArray dfsBuffer = Clay__layoutElementChildrenBuffer;

--- a/clay.h
+++ b/clay.h
@@ -2239,7 +2239,6 @@ void Clay__CalculateFinalLayout() {
             textElementData->wrappedLines.length++;
             continue;
         }
-        int32_t previousWordIndex = -1;
         int32_t wordIndex = measureTextCacheItem->measuredWordsStartIndex;
         while (wordIndex != -1) {
             Clay__MeasuredWord *measuredWord = Clay__MeasuredWordArray_Get(&Clay__measuredWords, wordIndex);

--- a/clay.h
+++ b/clay.h
@@ -487,7 +487,7 @@ extern bool Clay__debugMaxElementsLatch;
 #endif
 
 #ifndef CLAY_MAX_ELEMENT_COUNT
-#define CLAY_MAX_ELEMENT_COUNT 8192
+#define CLAY_MAX_ELEMENT_COUNT 256
 #endif
 
 #ifndef CLAY__TEXT_MEASURE_HASH_BUCKET_COUNT
@@ -1159,7 +1159,6 @@ Clay_LayoutElementHashMapItem *Clay__LayoutElementHashMapItemArray_Add(Clay__Lay
 
 typedef struct
 {
-    Clay_String word;
     uint32_t startOffset;
     uint32_t length;
     float width;
@@ -1628,11 +1627,11 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
             Clay_Dimensions dimensions = Clay__MeasureText(&word, config);
             if (current == ' ') {
                 dimensions.width += spaceWidth;
-                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .word = word, .next = -1, .startOffset = start, .length = length + 1, .width = dimensions.width }, previousWord);
+                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length + 1, .width = dimensions.width, .next = -1 }, previousWord);
             }
             if (current == '\n') {
-                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .word = word, .next = -1, .startOffset = start, .length = length, .width = dimensions.width }, previousWord);
-                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .word = word, .next = -1, .startOffset = end + 1, .length = 0, .width = 0 }, previousWord);
+                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length, .width = dimensions.width, .next = -1 }, previousWord);
+                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = end + 1, .length = 0, .width = 0, .next = -1 }, previousWord);
             }
             measuredWidth += dimensions.width;
             measuredHeight = dimensions.height;
@@ -1643,7 +1642,7 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
     if (end - start > 0) {
         Clay_String lastWord = CLAY__INIT(Clay_String) { .length = (int)(end - start), .chars = &text->chars[start] };
         Clay_Dimensions dimensions = Clay__MeasureText(&lastWord, config);
-        Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .word = lastWord, .next = -1, .startOffset = start, .length = end - start, .width = dimensions.width }, previousWord);
+        Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = end - start, .width = dimensions.width, .next = -1 }, previousWord);
         measuredWidth += dimensions.width;
         measuredHeight = dimensions.height;
     }
@@ -3623,7 +3622,7 @@ Clay_RenderCommandArray Clay_EndLayout()
         #endif
     }
     if (Clay__debugMaxElementsLatch) {
-        Clay_RenderCommandArray_Add(&Clay__renderCommands, CLAY__INIT(Clay_RenderCommand ) { .commandType = CLAY_RENDER_COMMAND_TYPE_TEXT, .boundingBox = { Clay__layoutDimensions.width / 2 - 59 * 4, Clay__layoutDimensions.height / 2 }, .text = CLAY_STRING("Clay Error: Layout elements exceeded CLAY_MAX_ELEMENT_COUNT"), .config = { .textElementConfig = &Clay__DebugView_ErrorTextConfig } });
+        Clay_RenderCommandArray_Add(&Clay__renderCommands, CLAY__INIT(Clay_RenderCommand ) { .boundingBox = { Clay__layoutDimensions.width / 2 - 59 * 4, Clay__layoutDimensions.height / 2 },  .config = { .textElementConfig = &Clay__DebugView_ErrorTextConfig }, .text = CLAY_STRING("Clay Error: Layout elements exceeded CLAY_MAX_ELEMENT_COUNT"), .commandType = CLAY_RENDER_COMMAND_TYPE_TEXT });
     } else {
         Clay__CalculateFinalLayout();
     }

--- a/clay.h
+++ b/clay.h
@@ -487,7 +487,7 @@ extern bool Clay__debugMaxElementsLatch;
 #endif
 
 #ifndef CLAY_MAX_ELEMENT_COUNT
-#define CLAY_MAX_ELEMENT_COUNT 512
+#define CLAY_MAX_ELEMENT_COUNT 8192
 #endif
 
 #ifndef CLAY__TEXT_MEASURE_HASH_BUCKET_COUNT

--- a/clay.h
+++ b/clay.h
@@ -2246,6 +2246,7 @@ void Clay__CalculateFinalLayout() {
             if (lineLengthChars == 0 && lineWidth + measuredWord->width > containerElement->dimensions.width) {
                 Clay__StringArray_Add(&Clay__wrappedTextLines, CLAY__INIT(Clay_String) {.length = (int)measuredWord->length, .chars = &textElementData->text.chars[measuredWord->startOffset] });
                 textElementData->wrappedLines.length++;
+                wordIndex = measuredWord->next;
             }
             // measuredWord->length == 0 means a newline character
             else if (measuredWord->length == 0 || lineWidth + measuredWord->width > containerElement->dimensions.width) {

--- a/clay.h
+++ b/clay.h
@@ -482,7 +482,7 @@ extern bool Clay__debugMaxElementsLatch;
 #ifdef CLAY_IMPLEMENTATION
 #undef CLAY_IMPLEMENTATION
 
-#ifdef CLAY_OVERFLOW_TRAP
+#ifdef CLAY_OVERFLOW_TRAP1
     #include "signal.h"
 #endif
 

--- a/clay.h
+++ b/clay.h
@@ -482,7 +482,7 @@ extern bool Clay__debugMaxElementsLatch;
 #ifdef CLAY_IMPLEMENTATION
 #undef CLAY_IMPLEMENTATION
 
-#ifdef CLAY_OVERFLOW_TRAP1
+#ifdef CLAY_OVERFLOW_TRAP
     #include "signal.h"
 #endif
 

--- a/examples/cairo-pdf-rendering/CMakeLists.txt
+++ b/examples/cairo-pdf-rendering/CMakeLists.txt
@@ -4,11 +4,11 @@ set(CMAKE_C_STANDARD 99)
 
 add_executable(clay_examples_cairo_pdf_rendering main.c)
 
-target_compile_options(clay_examples_cairo_pdf_rendering PUBLIC -DCLAY_DEBUG -DCLAY_OVERFLOW_TRAP -Wall -Werror -Wno-unknown-pragmas -g3 -O0)
+target_compile_options(clay_examples_cairo_pdf_rendering PUBLIC)
 target_include_directories(clay_examples_cairo_pdf_rendering PUBLIC .)
 
 target_link_libraries(clay_examples_cairo_pdf_rendering PUBLIC cairo)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 add_custom_command(

--- a/examples/clay-official-website/CMakeLists.txt
+++ b/examples/clay-official-website/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_C_STANDARD 99)
 
 add_executable(clay_official_website main.c)
 
-target_compile_options(clay_official_website PUBLIC -Wall -Werror -Wno-unknown-pragmas)
+target_compile_options(clay_official_website PUBLIC -Wall -Werror)
 target_include_directories(clay_official_website PUBLIC .)
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")

--- a/examples/clay-official-website/CMakeLists.txt
+++ b/examples/clay-official-website/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_C_STANDARD 99)
 
 add_executable(clay_official_website main.c)
 
-target_compile_options(clay_official_website PUBLIC -Wall -Werror)
+target_compile_options(clay_official_website PUBLIC -Wall -Werror -Wno-unknown-pragmas)
 target_include_directories(clay_official_website PUBLIC .)
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")

--- a/examples/raylib-sidebar-scrolling-container/CMakeLists.txt
+++ b/examples/raylib-sidebar-scrolling-container/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_options(clay_examples_raylib_sidebar_scrolling_container PUBLIC)
 target_include_directories(clay_examples_raylib_sidebar_scrolling_container PUBLIC .)
 
 target_link_libraries(clay_examples_raylib_sidebar_scrolling_container PUBLIC raylib)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror -DCLAY_DEBUG -DCLAY_OVERFLOW_TRAP")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror -DCLAY_DEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 add_custom_command(


### PR DESCRIPTION
This PR greatly improves the story around capacity overflows in various internal data structures.

Currently there are still some unsolved (but not unsolvable) problems:

- Text will not be rendered if `CLAY_MEASURE_TEXT_CACHE_SIZE` is exceeded.
- The error screen for exceeding `CLAY_MAX_ELEMENT_COUNT` is quite severe and non configurable:

<img width="593" alt="Screenshot 2024-11-30 at 7 42 52 pm" src="https://github.com/user-attachments/assets/b2a0c442-43e4-4fc5-83cc-4fdee57434ca">
