### PR TITLE
Extract Clay Renderer API into a separate header file

### DIFF
--- a/renderers/cairo/clay_renderer_cairo.c
+++ b/renderers/cairo/clay_renderer_cairo.c
@@ -34,10 +34,11 @@
 
 // TODO: We should use the given `uint16_t fontId` instead of doing this.
 #define CLAY_EXTEND_CONFIG_TEXT Clay_String fontFamily; // Font family
-#define CLAY_IMPLEMENTATION
-#include "../../clay.h"
+#include "../clay_renderer.h"
 
 #include <cairo/cairo.h>
+
+typedef struct caito_t Clay_Renderer_Data;
 
 ////////////////////////////////
 //
@@ -45,12 +46,12 @@
 //
 
 // Initialize the internal cairo pointer with the user provided instance.
-// This is REQUIRED before calling Clay_Cairo_Render.
-void Clay_Cairo_Initialize(cairo_t *cairo);
+// This is REQUIRED before calling Clay_Renderer_Render.
+void Clay_Renderer_Initialize(struct Clay_Renderer_Data *cairo);
 
 // Render the command queue to the `cairo_t*` instance you called
-// `Clay_Cairo_Initialize` on.
-void Clay_Cairo_Render(Clay_RenderCommandArray commands);
+// `Clay_Renderer_Initialize` on.
+void Clay_Renderer_Render(Clay_RenderCommandArray commands);
 ////////////////////////////////
 
 
@@ -83,7 +84,7 @@ static inline char *Clay_Cairo__NullTerminate(Clay_String *str) {
 }
 
 // Measure text using cairo's *toy* text API.
-static inline Clay_Dimensions Clay_Cairo_MeasureText(Clay_String *str, Clay_TextElementConfig *config) {
+inline Clay_Dimensions Clay_Renderer_MeasureText(Clay_String *str, Clay_TextElementConfig *config) {
 	// Edge case: Clay computes the width of a whitespace character
 	// once.  Cairo does not factor in whitespaces when computing text
 	// extents, this edge-case serves as a short-circuit to introduce
@@ -159,8 +160,8 @@ static inline Clay_Dimensions Clay_Cairo_MeasureText(Clay_String *str, Clay_Text
 }
 
 
-void Clay_Cairo_Initialize(cairo_t *cairo) {
-	Clay__Cairo = cairo;
+void Clay_Renderer_Initialize(struct Clay_Renderer_Data *cairo) {
+	Clay__Cairo = (cairo_t *)cairo;
 }
 
 // Internally used to copy images onto our document/active workspace.
@@ -191,7 +192,7 @@ void Clay_Cairo__Blit_Surface(cairo_surface_t *src_surface, cairo_surface_t *des
 	cairo_destroy(cr);
 }
 
-void Clay_Cairo_Render(Clay_RenderCommandArray commands) {
+void Clay_Renderer_Render(Clay_RenderCommandArray commands) {
 	cairo_t *cr = Clay__Cairo;
 	for(size_t i = 0; i < commands.length; i++) {
 		Clay_RenderCommand *command = Clay_RenderCommandArray_Get(&commands, i);

--- a/renderers/clay_renderer.h
+++ b/renderers/clay_renderer.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../clay.h"
+
+struct Clay_Renderer_Data;
+void Clay_Renderer_Initialize(struct Clay_Renderer_Data *data);
+void Clay_Renderer_Render(Clay_RenderCommandArray renderCommands);
+Clay_Dimensions Clay_Renderer_MeasureText(Clay_String *text, Clay_TextElementConfig *config);

--- a/renderers/raylib/clay_renderer_raylib.c
+++ b/renderers/raylib/clay_renderer_raylib.c
@@ -1,3 +1,4 @@
+#include "../clay_renderer.h"
 #include "raylib.h"
 #include "raymath.h"
 #include "stdint.h"
@@ -8,8 +9,21 @@
 #include "signal.h"
 #endif
 
-#define CLAY_RECTANGLE_TO_RAYLIB_RECTANGLE(rectangle) (Rectangle) { .x = rectangle.x, .y = rectangle.y, .width = rectangle.width, .height = rectangle.height }
-#define CLAY_COLOR_TO_RAYLIB_COLOR(color) (Color) { .r = (unsigned char)roundf(color.r), .g = (unsigned char)roundf(color.g), .b = (unsigned char)roundf(color.b), .a = (unsigned char)roundf(color.a) }
+#define CLAY_RECTANGLE_TO_RAYLIB_RECTANGLE(rectangle)   \
+    (Rectangle) {                                       \
+        .x = rectangle.x,                               \
+        .y = rectangle.y,                               \
+        .width = rectangle.width,                       \
+        .height = rectangle.height                      \
+    }
+
+#define CLAY_COLOR_TO_RAYLIB_COLOR(color)       \
+    (Color) {                                   \
+        .r = (unsigned char)roundf(color.r),    \
+        .g = (unsigned char)roundf(color.g),    \
+        .b = (unsigned char)roundf(color.b),    \
+        .a = (unsigned char)roundf(color.a)     \
+    }
 
 typedef struct
 {
@@ -42,7 +56,7 @@ typedef struct
 } CustomLayoutElement;
 
 // Get a ray trace from the screen position (i.e mouse) within a specific section of the screen
-Ray GetScreenToWorldPointWithZDistance(Vector2 position, Camera camera, int screenWidth, int screenHeight, float zDistance)
+static Ray GetScreenToWorldPointWithZDistance(Vector2 position, Camera camera, int screenWidth, int screenHeight, float zDistance)
 {
     Ray ray = { 0 };
 
@@ -92,7 +106,7 @@ Ray GetScreenToWorldPointWithZDistance(Vector2 position, Camera camera, int scre
 
 uint32_t measureCalls = 0;
 
-static inline Clay_Dimensions Raylib_MeasureText(Clay_String *text, Clay_TextElementConfig *config) {
+inline Clay_Dimensions Clay_Renderer_MeasureText(Clay_String *text, Clay_TextElementConfig *config) {
     measureCalls++;
     // Measure string size for Font
     Clay_Dimensions textSize = { 0 };
@@ -124,13 +138,20 @@ static inline Clay_Dimensions Raylib_MeasureText(Clay_String *text, Clay_TextEle
     return textSize;
 }
 
-void Clay_Raylib_Initialize(int width, int height, const char *title, unsigned int flags) {
-    SetConfigFlags(flags);
-    InitWindow(width, height, title);
-//    EnableEventWaiting();
+struct Clay_Renderer_Data {
+    int width;
+    int height;
+    const char *title;
+    unsigned int flags;
+};
+
+void Clay_Renderer_Initialize(struct Clay_Renderer_Data *data) {
+    SetConfigFlags(data->flags);
+    InitWindow(data->width, data->height, data->title);
+    // EnableEventWaiting();
 }
 
-void Clay_Raylib_Render(Clay_RenderCommandArray renderCommands)
+void Clay_Renderer_Render(Clay_RenderCommandArray renderCommands)
 {
     measureCalls = 0;
     for (int j = 0; j < renderCommands.length; j++)


### PR DESCRIPTION
In order to not depend on the specific renderer I suggest extracting renderer functions into its own header api file. Here what I did:

- Extracted clay_renderer_raylib.h;
- Modified Raylib and Cairo renderers to follow renderer api;

For Clay_Renderer_Initialize I've created an opaque struct type Clay_Renderer_Data so each renderer can populate its own config: for Raylib it's just window dimensions, title, and flags, for Cairo it's cairo_t type.

I'm not sure if it's ok to modify Cairo renderer, as it has own License notice.