### PR TITLE
[Renderers/Cairo] Add FindCairo.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 project(clay)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 add_subdirectory("examples/cpp-project-example")
 
 # Don't try to compile C99 projects using MSVC

--- a/cmake/FindCairo.cmake
+++ b/cmake/FindCairo.cmake
@@ -1,0 +1,32 @@
+# Defines:
+#  CAIRO_FOUND        - System has Cairo
+#  CAIRO_INCLUDE_DIRS - Cairo include directories
+#  CAIRO_LIBRARY      - Cairo library
+#  Cairo::Cairo       - Imported target
+
+find_path(CAIRO_INCLUDE_DIRS
+        NAMES cairo/cairo.h
+        PATHS ${CAIRO_ROOT_DIR}
+        PATH_SUFFIXES include
+)
+
+find_library(CAIRO_LIBRARY
+        NAMES cairo
+        PATHS ${CAIRO_ROOT_DIR}
+        PATH_SUFFIXES lib lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Cairo
+        REQUIRED_VARS CAIRO_LIBRARY CAIRO_INCLUDE_DIRS
+)
+
+if(Cairo_FOUND AND NOT TARGET Cairo::Cairo)
+    add_library(Cairo::Cairo UNKNOWN IMPORTED)
+    set_target_properties(Cairo::Cairo PROPERTIES
+            IMPORTED_LOCATION "${CAIRO_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${CAIRO_INCLUDE_DIRS}"
+    )
+endif()
+
+mark_as_advanced(CAIRO_INCLUDE_DIRS CAIRO_LIBRARY)

--- a/examples/cairo-pdf-rendering/CMakeLists.txt
+++ b/examples/cairo-pdf-rendering/CMakeLists.txt
@@ -13,8 +13,8 @@ target_compile_options(clay_examples_cairo_pdf_rendering PUBLIC)
 target_include_directories(clay_examples_cairo_pdf_rendering PUBLIC . ${CAIRO_INCLUDE_DIRS})
 
 target_link_libraries(clay_examples_cairo_pdf_rendering PUBLIC Cairo::Cairo)
-set(CMAKE_C_FLAGS_DEBUG "-Wall -Werror")
-set(CMAKE_C_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 add_custom_command(
         TARGET clay_examples_cairo_pdf_rendering POST_BUILD

--- a/examples/cairo-pdf-rendering/CMakeLists.txt
+++ b/examples/cairo-pdf-rendering/CMakeLists.txt
@@ -2,14 +2,19 @@ cmake_minimum_required(VERSION 3.27)
 project(clay_examples_cairo_pdf_rendering C)
 set(CMAKE_C_STANDARD 99)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+
+
 add_executable(clay_examples_cairo_pdf_rendering main.c)
 
-target_compile_options(clay_examples_cairo_pdf_rendering PUBLIC)
-target_include_directories(clay_examples_cairo_pdf_rendering PUBLIC .)
+find_package(Cairo REQUIRED)
 
-target_link_libraries(clay_examples_cairo_pdf_rendering PUBLIC cairo)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+target_compile_options(clay_examples_cairo_pdf_rendering PUBLIC)
+target_include_directories(clay_examples_cairo_pdf_rendering PUBLIC . ${CAIRO_INCLUDE_DIRS})
+
+target_link_libraries(clay_examples_cairo_pdf_rendering PUBLIC Cairo::Cairo)
+set(CMAKE_C_FLAGS_DEBUG "-Wall -Werror")
+set(CMAKE_C_FLAGS_RELEASE "-O3")
 
 add_custom_command(
         TARGET clay_examples_cairo_pdf_rendering POST_BUILD


### PR DESCRIPTION
At least on my OSX system, even with `brew install cairo`, cairo isn't found by the C compiler in the standard locations. Calling `FindPackage` with this FindCairo.cmake script and then explicitly linking and including the library solves the issue.
