### PR TITLE
Fixed compilation when using Clang on Windows

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -134,7 +134,7 @@ CLAY__ALIGNMENT_STRUCT(bool);
 CLAY__ALIGNMENT_STRUCT(uint8_t);
 CLAY__ALIGNMENT_STRUCT(int32_t);
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define CLAY_PACKED_ENUM __pragma(pack(push, 1)) enum __pragma(pack(pop))
 #else
 #define CLAY_PACKED_ENUM enum __attribute__((__packed__))


### PR DESCRIPTION
Clang on Windows defines `_MSC_VER` so using it for the definition of `CLAY_PACKED_ENUM` makes it use `__pragma` with Clang, which it cannot understand. This PR fixes it by replacing `#ifdef _MSC_VER` with `#if defined(_MSC_VER) && !defined(__clang__)`.