### PR TITLE
[Compilers] C++ projects should use CXX flags

### DIFF
--- a/examples/cpp-project-example/CMakeLists.txt
+++ b/examples/cpp-project-example/CMakeLists.txt
@@ -8,5 +8,5 @@ add_executable(clay_examples_cpp_project_example main.cpp)
 
 target_include_directories(clay_examples_cpp_project_example PUBLIC .)
 
-set(CMAKE_C_FLAGS_DEBUG "-Werror -Wall -Wno-error=missing-braces")
-set(CMAKE_C_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_DEBUG "-Werror -Wall -Wno-error=missing-braces")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")


### PR DESCRIPTION
It seems I made a whoopsie in #123 and edited the CXX flags of the example C++ project. This fixes that.
