### PR TITLE
Add a function to reset text measurement cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,12 @@ For help starting out or to discuss clay, considering joining [the discord serve
     - [Clay_MinMemorySize](#clay_minmemorysize)
     - [Clay_CreateArenaWithCapacityAndMemory](#clay_createarenawithcapacityandmemory)
     - [Clay_SetMeasureTextFunction](#clay_setmeasuretextfunction)
+    - [Clay_ResetMeasureTextCache](#clau_resetmeasuretextcache)
     - [Clay_SetMaxElementCount](clay_setmaxelementcount)
     - [Clay_SetMaxMeasureTextCacheWordCount](#clay_setmaxmeasuretextcachewordcount)
     - [Clay_Initialize](#clay_initialize)
+    - [Clay_GetCurrentContext](#clay_getcurrentcontext)
+    - [Clay_SetCurrentContext](#clay_setcurrentcontext)
     - [Clay_SetLayoutDimensions](#clay_setlayoutdimensions)
     - [Clay_SetPointerState](#clay_setpointerstate)
     - [Clay_UpdateScrollContainers](#clay_updatescrollcontainers)
@@ -575,6 +578,14 @@ Takes a pointer to a function that can be used to measure the `width, height` di
 
 ---
 
+### Clay_ResetMeasureTextCache
+
+`void Clay_ResetMeasureTextCache(void)`
+
+Clay caches measurements from the provided MeasureTextFunction, and this will be sufficient for the majority of use-cases. However, if the measurements can depend on external factors that clay does not know about, like DPI changes, then the cached values may be incorrect. When one of these external factors changes, Clay_ResetMeasureTextCache can be called to force clay to recalculate all string measurements in the next frame.
+
+---
+
 ### Clay_SetMaxElementCount
 
 `void Clay_SetMaxElementCount(uint32_t maxElementCount)`
@@ -603,11 +614,15 @@ Initializes the internal memory mapping, sets the internal dimensions for layout
 
 Reference: [Clay_Arena](#clay_createarenawithcapacityandmemory), [Clay_ErrorHandler](#clay_errorhandler), [Clay_SetCurrentContext](#clay_setcurrentcontext)
 
+---
+
 ### Clay_SetCurrentContext
 
 `void Clay_SetCurrentContext(Clay_Context* context)`
 
 Sets the context that subsequent clay commands will operate on. You can get this reference from [Clay_Initialize](#clay_initialize) or [Clay_GetCurrentContext](#clay_getcurrentcontext). See [Running more than one Clay instance](#running-more-than-one-clay-instance).
+
+---
 
 ### Clay_GetCurrentContext
 

--- a/clay.h
+++ b/clay.h
@@ -521,6 +521,7 @@ int32_t Clay_GetMaxElementCount(void);
 void Clay_SetMaxElementCount(int32_t maxElementCount);
 int32_t Clay_GetMaxMeasureTextCacheWordCount(void);
 void Clay_SetMaxMeasureTextCacheWordCount(int32_t maxMeasureTextCacheWordCount);
+void Clay_ResetMeasureTextCache(void);
 
 // Internal API functions required by macros
 void Clay__OpenElement(void);
@@ -1411,11 +1412,11 @@ struct Clay_Context {
     Clay__LayoutElementTreeRootArray layoutElementTreeRoots;
     Clay__LayoutElementHashMapItemArray layoutElementsHashMapInternal;
     Clay__int32_tArray layoutElementsHashMap;
-    Clay__MeasureTextCacheItemArray measureTextHashMapInternal;
-    Clay__int32_tArray measureTextHashMapInternalFreeList;
-    Clay__int32_tArray measureTextHashMap;
-    Clay__MeasuredWordArray measuredWords;
-    Clay__int32_tArray measuredWordsFreeList;
+        Clay__MeasureTextCacheItemArray measureTextHashMapInternal;
+        Clay__int32_tArray measureTextHashMapInternalFreeList;
+        Clay__int32_tArray measureTextHashMap;
+        Clay__MeasuredWordArray measuredWords;
+        Clay__int32_tArray measuredWordsFreeList;
     Clay__int32_tArray openClipElementStack;
     Clay__ElementIdArray pointerOverIds;
     Clay__ScrollContainerDataInternalArray scrollContainerDatas;
@@ -4010,6 +4011,21 @@ void Clay_SetMaxMeasureTextCacheWordCount(int32_t maxMeasureTextCacheWordCount) 
     } else {
         Clay__defaultMaxMeasureTextWordCacheCount = maxMeasureTextCacheWordCount; // TODO: Fix this
     }
+}
+
+CLAY_WASM_EXPORT("Clay_ResetMeasureTextCache")
+void Clay_ResetMeasureTextCache(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->measureTextHashMapInternal.length = 0;
+    context->measureTextHashMapInternalFreeList.length = 0;
+    context->measureTextHashMap.length = 0;
+    context->measuredWords.length = 0;
+    context->measuredWordsFreeList.length = 0;
+    
+    for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
+        context->measureTextHashMap.internalArray[i] = 0;
+    }
+    context->measureTextHashMapInternal.length = 1; // Reserve the 0 value to mean "no next element"
 }
 
 #endif // CLAY_IMPLEMENTATION

--- a/clay.h
+++ b/clay.h
@@ -1412,11 +1412,11 @@ struct Clay_Context {
     Clay__LayoutElementTreeRootArray layoutElementTreeRoots;
     Clay__LayoutElementHashMapItemArray layoutElementsHashMapInternal;
     Clay__int32_tArray layoutElementsHashMap;
-        Clay__MeasureTextCacheItemArray measureTextHashMapInternal;
-        Clay__int32_tArray measureTextHashMapInternalFreeList;
-        Clay__int32_tArray measureTextHashMap;
-        Clay__MeasuredWordArray measuredWords;
-        Clay__int32_tArray measuredWordsFreeList;
+    Clay__MeasureTextCacheItemArray measureTextHashMapInternal;
+    Clay__int32_tArray measureTextHashMapInternalFreeList;
+    Clay__int32_tArray measureTextHashMap;
+    Clay__MeasuredWordArray measuredWords;
+    Clay__int32_tArray measuredWordsFreeList;
     Clay__int32_tArray openClipElementStack;
     Clay__ElementIdArray pointerOverIds;
     Clay__ScrollContainerDataInternalArray scrollContainerDatas;


### PR DESCRIPTION
Allows clearing the text measurement cache if needed.