### PR TITLE
Fixing rendering of lines that contain a single character

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1704,7 +1704,7 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
                 previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length + 1, .width = dimensions.width, .next = -1 }, previousWord);
             }
             if (current == '\n') {
-                if (length > 1) {
+                if (length >= 1) {
                     previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length, .width = dimensions.width, .next = -1 }, previousWord);
                 }
                 previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = end + 1, .length = 0, .width = 0, .next = -1 }, previousWord);


### PR DESCRIPTION
Fixes https://github.com/nicbarker/clay/issues/188

A line with a single character is length 1, but the check is only checking for lengths of 2 or more