### PR TITLE
[CMake] Make Examples Optional in CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,21 +3,38 @@ project(clay)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-option(CLAY_INCLUDE_EXAMPLES "Build examples" OFF)
+option(CLAY_INCLUDE_ALL_EXAMPLES "Build all examples" OFF)
+option(CLAY_INCLUDE_DEMOS "Build video demo and website" ON)
+option(CLAY_INCLUDE_CPP_EXAMPLE "Build C++ example" OFF)
+option(CLAY_INCLUDE_RAYLIB_EXAMPLES "Build raylib examples" OFF)
+option(CLAY_INCLUDE_SDL2_EXAMPLES "Build SDL 2 examples" OFF)
+option(CLAY_INCLUDE_SDL3_EXAMPLES "Build SDL 3 examples" OFF)
+
+message(STATUS "CLAY_INCLUDE_DEMOS: ${CLAY_INCLUDE_DEMOS}")
 
 if(APPLE)
   enable_language(OBJC)
 endif()
 
-if(CLAY_INCLUDE_EXAMPLES)
+if(CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_CPP_EXAMPLE)
   add_subdirectory("examples/cpp-project-example")
-  add_subdirectory("examples/raylib-multi-context")
-  add_subdirectory("examples/raylib-sidebar-scrolling-container")
-  #  add_subdirectory("examples/cairo-pdf-rendering") Some issue with github actions populating cairo, disable for now
+endif()
+if(CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_DEMOS)
   if(NOT MSVC)
     add_subdirectory("examples/clay-official-website")
-    add_subdirectory("examples/SDL3-simple-demo")
   endif()
   add_subdirectory("examples/introducing-clay-video-demo")
+endif ()
+
+if(CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_RAYLIB_EXAMPLES)
+  add_subdirectory("examples/raylib-multi-context")
+  add_subdirectory("examples/raylib-sidebar-scrolling-container")
+endif ()
+if(CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_SDL2_EXAMPLES)
   add_subdirectory("examples/SDL2-video-demo")
+endif ()
+if(NOT MSVC AND (CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_SDL3_EXAMPLES))
+    add_subdirectory("examples/SDL3-simple-demo")
 endif()
+
+#  add_subdirectory("examples/cairo-pdf-rendering") Some issue with github actions populating cairo, disable for now

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(clay)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-option(CLAY_INCLUDE_ALL_EXAMPLES "Build all examples" OFF)
-option(CLAY_INCLUDE_DEMOS "Build video demo and website" ON)
+option(CLAY_INCLUDE_ALL_EXAMPLES "Build all examples" ON)
+option(CLAY_INCLUDE_DEMOS "Build video demo and website" OFF)
 option(CLAY_INCLUDE_CPP_EXAMPLE "Build C++ example" OFF)
 option(CLAY_INCLUDE_RAYLIB_EXAMPLES "Build raylib examples" OFF)
 option(CLAY_INCLUDE_SDL2_EXAMPLES "Build SDL 2 examples" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,21 @@ project(clay)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+option(CLAY_INCLUDE_EXAMPLES "Build examples" OFF)
+
 if(APPLE)
   enable_language(OBJC)
 endif()
 
-add_subdirectory("examples/cpp-project-example")
-add_subdirectory("examples/raylib-multi-context")
-add_subdirectory("examples/raylib-sidebar-scrolling-container")
-#  add_subdirectory("examples/cairo-pdf-rendering") Some issue with github actions populating cairo, disable for now
-if(NOT MSVC)
-  add_subdirectory("examples/clay-official-website")
-  add_subdirectory("examples/SDL3-simple-demo")
+if(CLAY_INCLUDE_EXAMPLES)
+  add_subdirectory("examples/cpp-project-example")
+  add_subdirectory("examples/raylib-multi-context")
+  add_subdirectory("examples/raylib-sidebar-scrolling-container")
+  #  add_subdirectory("examples/cairo-pdf-rendering") Some issue with github actions populating cairo, disable for now
+  if(NOT MSVC)
+    add_subdirectory("examples/clay-official-website")
+    add_subdirectory("examples/SDL3-simple-demo")
+  endif()
+  add_subdirectory("examples/introducing-clay-video-demo")
+  add_subdirectory("examples/SDL2-video-demo")
 endif()
-add_subdirectory("examples/introducing-clay-video-demo")
-add_subdirectory("examples/SDL2-video-demo")


### PR DESCRIPTION
Makes including the examples optional.  SDL2/SDL3 specifically have long download/build times.  If they aren't being used, then this can dramatically speed up build times.