### PR TITLE
[Renderers/SDL3] Add borders and rounded borders functionality.

### DIFF
--- a/examples/SDL3-simple-demo/main.c
+++ b/examples/SDL3-simple-demo/main.c
@@ -33,12 +33,12 @@ static inline Clay_Dimensions SDL_MeasureText(Clay_StringSlice text, Clay_TextEl
     return (Clay_Dimensions) { (float) width, (float) height };
 }
 
-static void Label(const Clay_String text)
+static void Label(const Clay_String text, const int cornerRadius)
 {
     CLAY(CLAY_LAYOUT({ .padding = {8, 8} }),
         CLAY_RECTANGLE({
             .color = Clay_Hovered() ? COLOR_BLUE : COLOR_ORANGE,
-            .cornerRadius = (Clay_CornerRadius){ 8, 8, 8, 8 },
+            .cornerRadius = cornerRadius,
         })) {
         CLAY_TEXT(text, CLAY_TEXT_CONFIG({
            .textColor = { 255, 255, 255, 255 },
@@ -46,6 +46,24 @@ static void Label(const Clay_String text)
            .fontSize = 24,
         }));
    }
+}
+
+static void LabelBorder(const Clay_String text, const int cornerRadius)
+{
+    CLAY(
+        CLAY_LAYOUT({
+            .padding = {8, 8} }),
+            CLAY_BORDER_OUTSIDE_RADIUS(
+                2,
+                COLOR_BLUE,
+                cornerRadius)
+    ){
+        CLAY_TEXT(text, CLAY_TEXT_CONFIG({
+           .textColor = { 255, 255, 255, 255 },
+           .fontId = FONT_ID,
+           .fontSize = 24,
+        }));
+    }
 }
 
 static Clay_RenderCommandArray Clay_CreateLayout()
@@ -65,13 +83,20 @@ static Clay_RenderCommandArray Clay_CreateLayout()
             .padding = { 10, 10 },
             .layoutDirection = CLAY_TOP_TO_BOTTOM,
         }),
+        CLAY_BORDER({
+            .left = { 20, COLOR_BLUE },
+            .right = { 20, COLOR_BLUE },
+            .bottom = { 20, COLOR_BLUE }
+        }),
         CLAY_RECTANGLE({
             .color = COLOR_LIGHT,
         })
     ) {
-        Label(CLAY_STRING("Button 1"));
-        Label(CLAY_STRING("Button 2"));
-        Label(CLAY_STRING("Button 3"));
+        Label(CLAY_STRING("Rounded - Button 1"), 5);
+        Label(CLAY_STRING("Straight - Button 2") , 0);
+        Label(CLAY_STRING("Rounded+ - Button 3") , 20);
+        LabelBorder(CLAY_STRING("Border - Button 4"), 0);
+        LabelBorder(CLAY_STRING("RoundedBorder - Button 5"), 10);
     }
     return Clay_EndLayout();
 }

--- a/examples/SDL3-simple-demo/main.c
+++ b/examples/SDL3-simple-demo/main.c
@@ -48,13 +48,13 @@ static void Label(const Clay_String text, const int cornerRadius)
    }
 }
 
-static void LabelBorder(const Clay_String text, const int cornerRadius)
+static void LabelBorder(const Clay_String text, const int cornerRadius, const int thickness)
 {
     CLAY(
         CLAY_LAYOUT({
-            .padding = {8, 8} }),
+            .padding = {16, 16, 8, 8 } }),
             CLAY_BORDER_OUTSIDE_RADIUS(
-                2,
+                thickness,
                 COLOR_BLUE,
                 cornerRadius)
     ){
@@ -92,11 +92,12 @@ static Clay_RenderCommandArray Clay_CreateLayout()
             .color = COLOR_LIGHT,
         })
     ) {
-        Label(CLAY_STRING("Rounded - Button 1"), 5);
+        Label(CLAY_STRING("Rounded - Button 1"), 10);
         Label(CLAY_STRING("Straight - Button 2") , 0);
         Label(CLAY_STRING("Rounded+ - Button 3") , 20);
-        LabelBorder(CLAY_STRING("Border - Button 4"), 0);
-        LabelBorder(CLAY_STRING("RoundedBorder - Button 5"), 10);
+        LabelBorder(CLAY_STRING("Border - Button 4"), 0, 5);
+        LabelBorder(CLAY_STRING("RoundedBorder - Button 5"), 10, 5);
+        LabelBorder(CLAY_STRING("RoundedBorder - Button 6"), 40, 15);
     }
     return Clay_EndLayout();
 }

--- a/renderers/SDL3/README
+++ b/renderers/SDL3/README
@@ -1,5 +1,4 @@
 Please note, the SDL3 renderer is not 100% feature complete. It is currently missing:
 
-- Borders
 - Images
 - Scroll / Scissor handling

--- a/renderers/SDL3/clay_renderer_SDL3.c
+++ b/renderers/SDL3/clay_renderer_SDL3.c
@@ -2,7 +2,6 @@
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL.h>
 #include <SDL3_ttf/SDL_ttf.h>
-#include <math.h> //needed to perform the rounded corners rendering
 
 /* This needs to be global because the "MeasureText" callback doesn't have a
  * user data parameter */
@@ -18,8 +17,8 @@ static void SDL_RenderRoundedRect(SDL_Renderer *renderer, const SDL_FRect rect, 
 
     int indexCount = 0, vertexCount = 0;
 
-    const float minRadius = fminf(rect.w, rect.h) / 2.0f;
-    const float clampedRadius = fminf(cornerRadius, minRadius);
+    const float minRadius = SDL_min(rect.w, rect.h) / 2.0f;
+    const float clampedRadius = SDL_min(cornerRadius, minRadius);
 
     int totalVertices = 4 + (4 * (NUM_CIRCLE_SEGMENTS * 2)) + 2*4;
     int totalIndices = 6 + (4 * (NUM_CIRCLE_SEGMENTS * 3)) + 6*4;
@@ -41,9 +40,8 @@ static void SDL_RenderRoundedRect(SDL_Renderer *renderer, const SDL_FRect rect, 
     indices[indexCount++] = 3;
 
     //define rounded corners as triangle fans
-    const float step = M_PI_2 / NUM_CIRCLE_SEGMENTS;
-    for (int i = 0; i < NUM_CIRCLE_SEGMENTS; i++)
-    {
+    const float step = (SDL_PI_F/2) / NUM_CIRCLE_SEGMENTS;
+    for (int i = 0; i < NUM_CIRCLE_SEGMENTS; i++) {
         const float angle1 = (float)i * step;
         const float angle2 = ((float)i + 1.0f) * step;
 
@@ -58,8 +56,8 @@ static void SDL_RenderRoundedRect(SDL_Renderer *renderer, const SDL_FRect rect, 
                 default: SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Invalid corner index"); return;
             }
 
-            vertices[vertexCount++] = (SDL_Vertex){ {cx + cosf(angle1) * clampedRadius * signX, cy + sinf(angle1) * clampedRadius * signY}, color, {0, 0} };
-            vertices[vertexCount++] = (SDL_Vertex){ {cx + cosf(angle2) * clampedRadius * signX, cy + sinf(angle2) * clampedRadius * signY}, color, {0, 0} };
+            vertices[vertexCount++] = (SDL_Vertex){ {cx + SDL_cosf(angle1) * clampedRadius * signX, cy + SDL_sinf(angle1) * clampedRadius * signY}, color, {0, 0} };
+            vertices[vertexCount++] = (SDL_Vertex){ {cx + SDL_cosf(angle2) * clampedRadius * signX, cy + SDL_sinf(angle2) * clampedRadius * signY}, color, {0, 0} };
 
             indices[indexCount++] = j;  // Connect to corresponding central rectangle vertex
             indices[indexCount++] = vertexCount - 2;


### PR DESCRIPTION
Added borders, including rounded borders, one of the missing features for the SDL3 renderer.
Also added examples in the SDL3 example.