### PR TITLE
Fix: Clay_MinMemorySize() and Clay_Initialize() now report same memory size when using non-default MaxElementCount

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3773,7 +3773,7 @@ Clay_Context* Clay_Initialize(Clay_Arena arena, Clay_Dimensions layoutDimensions
     Clay_Context *oldContext = Clay_GetCurrentContext();
     *context = CLAY__INIT(Clay_Context) {
         .maxElementCount = oldContext ? oldContext->maxElementCount : Clay__defaultMaxElementCount,
-        .maxMeasureTextCacheWordCount = oldContext ? oldContext->maxMeasureTextCacheWordCount : Clay__defaultMaxElementCount * 2,
+        .maxMeasureTextCacheWordCount = oldContext ? oldContext->maxMeasureTextCacheWordCount : Clay__defaultMaxMeasureTextWordCacheCount,
         .errorHandler = errorHandler.errorHandlerFunction ? errorHandler : CLAY__INIT(Clay_ErrorHandler) { Clay__ErrorHandlerFunctionDefault },
         .layoutDimensions = layoutDimensions,
         .internalArena = arena,
@@ -4077,6 +4077,7 @@ void Clay_SetMaxElementCount(int32_t maxElementCount) {
         context->maxElementCount = maxElementCount;
     } else {
         Clay__defaultMaxElementCount = maxElementCount; // TODO: Fix this
+	Clay__defaultMaxMeasureTextWordCacheCount = maxElementCount * 2;
     }
 }
 


### PR DESCRIPTION
Normalized usage of `Clay__defaultMaxElementCount` and `Clay__defaultMaxMeasureTextWordCacheCount`

This is important - especially - between calls to `Clay_MinMemorySize()` and `Clay_Initialize()` as there was a bug that caused initialization errors when a non-default value is used (in my case `Clay_SetMaxElementCount(8192*2);`).

Repo:

```
int main(int argc, char* argv[])
{
    Clay_SetMaxElementCount(8192 * 2);
    uint64_t totalMemorySize = Clay_MinMemorySize();
    Clay_Arena clayMemory = Clay_CreateArenaWithCapacityAndMemory(totalMemorySize, malloc(totalMemorySize));
    auto ctx = Clay_Initialize(clayMemory, { (float)GetScreenWidth(), (float)GetScreenHeight() }, { HandleClayErrors });
    auto next = ctx->internalArena.nextAllocation;
    long diff = next - totalMemorySize; //diff will show a negative number, and several internal arrays will fail to allocate
}
```

I did note the` // TODO: Fix this` so if there are some other plans to address this please ignore.

Thanks!