### PR TITLE
Clay__defaultMaxMeasureTextWordCacheCount is not used

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3773,7 +3773,7 @@ Clay_Context* Clay_Initialize(Clay_Arena arena, Clay_Dimensions layoutDimensions
     Clay_Context *oldContext = Clay_GetCurrentContext();
     *context = CLAY__INIT(Clay_Context) {
         .maxElementCount = oldContext ? oldContext->maxElementCount : Clay__defaultMaxElementCount,
-        .maxMeasureTextCacheWordCount = oldContext ? oldContext->maxMeasureTextCacheWordCount : Clay__defaultMaxElementCount * 2,
+        .maxMeasureTextCacheWordCount = oldContext ? oldContext->maxMeasureTextCacheWordCount : Clay__defaultMaxMeasureTextWordCacheCount,
         .errorHandler = errorHandler.errorHandlerFunction ? errorHandler : CLAY__INIT(Clay_ErrorHandler) { Clay__ErrorHandlerFunctionDefault },
         .layoutDimensions = layoutDimensions,
         .internalArena = arena,


### PR DESCRIPTION
The Clay__defaultMaxMeasureTextWordCacheCount is not use in the function Clay_Initialize. By now for the WordCacheCount value was element count * 2. This Mr fix it and use the correct variable for init the context. 

Without the changes Clay_Initialize can fail for non default values calculated by Clay_MinMemorySize

Thx