### PR TITLE
Define CLAY_IMPLEMENTATION in Jetbrains IDE

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -21,6 +21,11 @@
 #include <arm_neon.h>
 #endif
 
+#ifdef __JETBRAINS_IDE__
+// Help jetbrains IDEs like CLion and Rider with intellisense & debugging
+#define CLAY_IMPLEMENTATION
+#endif
+
 // -----------------------------------------
 // HEADER DECLARATIONS ---------------------
 // -----------------------------------------


### PR DESCRIPTION
[`__JETBRAINS_IDE__`](https://blog.jetbrains.com/clion/2017/02/clion-2017-1-eap-debugger-fixes-ide-macros-and-new-cmake/) is defined within Jetbrains editors like CLion and Rider. This is only defined inside the IDE, and does not affect builds, so we can use it to enable `CLAY_IMPLEMENTATION` to improve debugging & intellisense in this environment. I'm not sure if other IDEs have similar macros, but I figured we could start with this one.

Before:
![image](https://github.com/user-attachments/assets/269f04fb-e61d-40c5-b27f-5816f8401d74)

After:
![image](https://github.com/user-attachments/assets/834777ba-c726-4fa5-9b6e-29dad8365ea5)
