### PR TITLE
[Bindings/Odin] Add get/set current context method to Odin bindings

### DIFF
--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -339,6 +339,8 @@ ErrorHandler :: struct {
     userData: rawptr
 }
 
+Context :: struct {} // opaque structure, only use as a pointer
+
 @(link_prefix = "Clay_", default_calling_convention = "c")
 foreign Clay {
     MinMemorySize :: proc() -> u32 ---
@@ -355,6 +357,8 @@ foreign Clay {
     SetMeasureTextFunction :: proc(measureTextFunction: proc "c" (text: StringSlice, config: ^TextElementConfig, userData: uintptr) -> Dimensions, userData: uintptr) ---
     RenderCommandArray_Get :: proc(array: ^ClayArray(RenderCommand), index: i32) -> ^RenderCommand ---
     SetDebugModeEnabled :: proc(enabled: bool) ---
+    GetCurrentContext :: proc() -> ^Context ---
+    SetCurrentContext :: proc(ctx: ^Context) ---
 }
 
 @(link_prefix = "Clay_", default_calling_convention = "c", private)


### PR DESCRIPTION
This is useful for hot-reloading and was missing from the bindings. I don't know how much of the Context you want to expose, but I assume it should be opaque.