### PR TITLE
Fix a bug when trying to enable debug view with too many elements in the layout.

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3521,13 +3521,19 @@ CLAY_WASM_EXPORT("Clay_EndLayout")
 Clay_RenderCommandArray Clay_EndLayout(void) {
     Clay_Context* context = Clay_GetCurrentContext();
     Clay__CloseElement();
-    if (context->debugModeEnabled) {
+    bool elementsExceededBeforeDebugView = context->booleanWarnings.maxElementsExceeded;
+    if (context->debugModeEnabled && !elementsExceededBeforeDebugView) {
         context->warningsEnabled = false;
         Clay__RenderDebugView();
         context->warningsEnabled = true;
     }
     if (context->booleanWarnings.maxElementsExceeded) {
-        Clay_String message = CLAY_STRING("Clay Error: Layout elements exceeded Clay__maxElementCount");
+        Clay_String message;
+        if (!elementsExceededBeforeDebugView) {
+            message = CLAY_STRING("Clay Error: Layout elements exceeded Clay__maxElementCount after adding the debug-view to the layout.");
+        } else {
+            message = CLAY_STRING("Clay Error: Layout elements exceeded Clay__maxElementCount");
+        }
         Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand ) {
             .boundingBox = { context->layoutDimensions.width / 2 - 59 * 4, context->layoutDimensions.height / 2, 0, 0 },
             .renderData = { .text = { .stringContents = CLAY__INIT(Clay_StringSlice) { .length = message.length, .chars = message.chars, .baseChars = message.chars }, .textColor = {255, 0, 0, 255}, .fontSize = 16 } },


### PR DESCRIPTION
Check whether the maximum number of elements has been exceeded before rendering the debug view

If the maximum number of elements is exceeded, `Clay__CloseElement` does not append `openLayoutElement->childrenOrTextContent.children.elements`, which in turn causes a segfault (accessing `NULL`) when trying to render the debug view for that element. In addition, if the maximum number of elements was not exceeded, but the debug view rendering has exceeded it, a different warning message is displayed.