### PR TITLE
[Renderers/SDL2] Make SDL_RenderCornerBorder static

### DIFF
--- a/renderers/SDL2/clay_renderer_SDL2.c
+++ b/renderers/SDL2/clay_renderer_SDL2.c
@@ -146,7 +146,7 @@ static void SDL_RenderFillRoundedRect(SDL_Renderer* renderer, const SDL_FRect re
 }
 
 //all rendering is performed by a single SDL call, using twi sets of arcing triangles, inner and outer, that fit together; along with two tringles to fill the end gaps.
-void SDL_RenderCornerBorder(SDL_Renderer *renderer, Clay_BoundingBox* boundingBox, Clay_BorderRenderData* config, int cornerIndex, Clay_Color _color){
+static void SDL_RenderCornerBorder(SDL_Renderer *renderer, Clay_BoundingBox* boundingBox, Clay_BorderRenderData* config, int cornerIndex, Clay_Color _color){
     /////////////////////////////////
     //The arc is constructed of outer triangles and inner triangles (if needed).
     //First three vertices are first outer triangle's vertices


### PR DESCRIPTION
I oopsied and forgot to make the function static on last PR. Simple fix for [issue 262](https://github.com/nicbarker/clay/issues/262).