### PR TITLE
[Renderers/Raylib] Convert Image usage to Texture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,7 +1240,7 @@ Used to perform **aspect ratio scaling** on the image element. As of this versio
 
 ```C
 // Load an image somewhere in your code
-Image profilePicture = LoadImage("profilePicture.png");
+Texture profilePicture = LoadTexture("profilePicture.png");
 // Note that when rendering, .imageData will be void* type.
 CLAY({ .image = { .imageData = &profilePicture, .sourceDimensions = { 60, 60 } } }) {}
 ```
@@ -1249,7 +1249,7 @@ CLAY({ .image = { .imageData = &profilePicture, .sourceDimensions = { 60, 60 } }
 
 ```C
 // Load an image somewhere in your code
-Image profilePicture = LoadImage("profilePicture.png");
+Texture profilePicture = LoadTexture("profilePicture.png");
 // Declare a reusable image config
 Clay_ImageElementConfig imageConfig = (Clay_ImageElementConfig) { .imageData = &profilePicture, .sourceDimensions = {60, 60} };
 // Declare an image element using a reusable config
@@ -1257,7 +1257,7 @@ CLAY({ .image = imageConfig }) {}
 // Declare an image element using an inline config
 CLAY({ .image = { .imageData = &profilePicture, .sourceDimensions = {60, 60} } }) {}
 // Rendering example
-Image *imageToRender = renderCommand->elementConfig.imageElementConfig->imageData;
+Texture *imageToRender = renderCommand->elementConfig.imageElementConfig->imageData;
 ```
 
 **Rendering**

--- a/README.md
+++ b/README.md
@@ -1240,7 +1240,7 @@ Used to perform **aspect ratio scaling** on the image element. As of this versio
 
 ```C
 // Load an image somewhere in your code
-Texture profilePicture = LoadTexture("profilePicture.png");
+YourImage profilePicture = LoadYourImage("profilePicture.png");
 // Note that when rendering, .imageData will be void* type.
 CLAY({ .image = { .imageData = &profilePicture, .sourceDimensions = { 60, 60 } } }) {}
 ```
@@ -1249,7 +1249,7 @@ CLAY({ .image = { .imageData = &profilePicture, .sourceDimensions = { 60, 60 } }
 
 ```C
 // Load an image somewhere in your code
-Texture profilePicture = LoadTexture("profilePicture.png");
+YourImage profilePicture = LoadYourImage("profilePicture.png");
 // Declare a reusable image config
 Clay_ImageElementConfig imageConfig = (Clay_ImageElementConfig) { .imageData = &profilePicture, .sourceDimensions = {60, 60} };
 // Declare an image element using a reusable config
@@ -1257,7 +1257,7 @@ CLAY({ .image = imageConfig }) {}
 // Declare an image element using an inline config
 CLAY({ .image = { .imageData = &profilePicture, .sourceDimensions = {60, 60} } }) {}
 // Rendering example
-Texture *imageToRender = renderCommand->elementConfig.imageElementConfig->imageData;
+YourImage *imageToRender = renderCommand->elementConfig.imageElementConfig->imageData;
 ```
 
 **Rendering**

--- a/bindings/odin/examples/clay-official-website/clay-official-website.odin
+++ b/bindings/odin/examples/clay-official-website/clay-official-website.odin
@@ -509,12 +509,12 @@ main :: proc() {
     loadFont(FONT_ID_BODY_24, 24, "resources/Quicksand-Semibold.ttf")
     loadFont(FONT_ID_BODY_16, 16, "resources/Quicksand-Semibold.ttf")
 
-    syntaxImage = raylib.LoadTextureFromImage(raylib.LoadImage("resources/declarative.png"))
-    checkImage1 = raylib.LoadTextureFromImage(raylib.LoadImage("resources/check_1.png"))
-    checkImage2 = raylib.LoadTextureFromImage(raylib.LoadImage("resources/check_2.png"))
-    checkImage3 = raylib.LoadTextureFromImage(raylib.LoadImage("resources/check_3.png"))
-    checkImage4 = raylib.LoadTextureFromImage(raylib.LoadImage("resources/check_4.png"))
-    checkImage5 = raylib.LoadTextureFromImage(raylib.LoadImage("resources/check_5.png"))
+    syntaxImage = raylib.LoadTexture("resources/declarative.png")
+    checkImage1 = raylib.LoadTexture("resources/check_1.png")
+    checkImage2 = raylib.LoadTexture("resources/check_2.png")
+    checkImage3 = raylib.LoadTexture("resources/check_3.png")
+    checkImage4 = raylib.LoadTexture("resources/check_4.png")
+    checkImage5 = raylib.LoadTexture("resources/check_5.png")
 
     debugModeEnabled: bool = false
 

--- a/examples/raylib-sidebar-scrolling-container/main.c
+++ b/examples/raylib-sidebar-scrolling-container/main.c
@@ -227,7 +227,7 @@ int main(void) {
     Clay_Arena clayMemory = Clay_CreateArenaWithCapacityAndMemory(totalMemorySize, malloc(totalMemorySize));
     Clay_Initialize(clayMemory, (Clay_Dimensions) { (float)GetScreenWidth(), (float)GetScreenHeight() }, (Clay_ErrorHandler) { HandleClayErrors, 0 });
     Clay_Raylib_Initialize(1024, 768, "Clay - Raylib Renderer Example", FLAG_VSYNC_HINT | FLAG_WINDOW_RESIZABLE | FLAG_WINDOW_HIGHDPI | FLAG_MSAA_4X_HINT);
-    profilePicture = LoadTextureFromImage(LoadImage("resources/profile-picture.png"));
+    profilePicture = LoadTexture("resources/profile-picture.png");
 
     Font fonts[2];
     fonts[FONT_ID_BODY_24] = LoadFontEx("resources/Roboto-Regular.ttf", 48, 0, 400);


### PR DESCRIPTION
Some people in Discord were getting confused about this:

I dont think `Image` is meant to be used here but instead `Texture` (as used correctly for the Clay website, etc)
`Image` is on the CPU, `Texture` is on the GPU

Additionally,
`LoadImage()` + `LoadTextureFromImage()` without `UnloadImage()` causes a memory leak
raylib has a separate `LoadTexture()` that does the load+send to gpu+unload for you to simplify this