### PR TITLE
Make Clay_MinMemorySize accurate based on word cache count

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3589,7 +3589,7 @@ uint32_t Clay_MinMemorySize(void) {
     Clay_Context* currentContext = Clay_GetCurrentContext();
     if (currentContext) {
         fakeContext.maxElementCount = currentContext->maxElementCount;
-        fakeContext.maxMeasureTextCacheWordCount = currentContext->maxElementCount;
+        fakeContext.maxMeasureTextCacheWordCount = currentContext->maxMeasureTextCacheWordCount;
     }
     // Reserve space in the arena for the context, important for calculating min memory size correctly
     Clay__Context_Allocate_Arena(&fakeContext.internalArena);


### PR DESCRIPTION
This PR just ensures that MinMemorySize is accurate according to the `maxMeasureTextWordCacheCount` by ensuring `fakeContext` shares the same value as the `currentContext`. Found this after constantly running out of memory when dynamically adding lots of text.

Thanks for the amazing library!