### PR TITLE
Adds Clay_GetPointerState

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ For help starting out or to discuss clay, considering joining [the discord serve
     - [Clay_SetCurrentContext](#clay_setcurrentcontext)
     - [Clay_SetLayoutDimensions](#clay_setlayoutdimensions)
     - [Clay_SetPointerState](#clay_setpointerstate)
+    - [Clay_GetPointerState](#clay_getpointerstate)
     - [Clay_UpdateScrollContainers](#clay_updatescrollcontainers)
     - [Clay_BeginLayout](#clay_beginlayout)
     - [Clay_EndLayout](#clay_endlayout)
@@ -642,6 +643,14 @@ Sets the internal layout dimensions. Cheap enough to be called every frame with 
 `void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown)`
 
 Sets the internal pointer position and state (i.e. current mouse / touch position) and recalculates overlap info, which is used for mouseover / click calculation (via [Clay_PointerOver](#clay_pointerover) and updating scroll containers with [Clay_UpdateScrollContainers](#clay_updatescrollcontainers). **isPointerDown should represent the current state this frame, e.g. it should be `true` for the entire duration the left mouse button is held down.** Clay has internal handling for detecting click / touch start & end.
+
+---
+
+### Clay_GetPointerState
+
+`Clay_PointerData Clay_GetPointerState()`
+
+Get the internal pointer position and state (i.e. current mouse / touch position). returns clay internal click start and stop state.
 
 ---
 

--- a/clay.h
+++ b/clay.h
@@ -778,6 +778,9 @@ Clay_Arena Clay_CreateArenaWithCapacityAndMemory(uint32_t capacity, void *memory
 // Sets the state of the "pointer" (i.e. the mouse or touch) in Clay's internal data. Used for detecting and responding to mouse events in the debug view,
 // as well as for Clay_Hovered() and scroll element handling.
 void Clay_SetPointerState(Clay_Vector2 position, bool pointerDown);
+// Gets the state of the "pointer". This will return the position provided by `Clay_SetPointerState` 
+// and the frame pressed state.
+Clay_PointerData Clay_GetPointerState();
 // Initialize Clay's internal arena and setup required data before layout can begin. Only needs to be called once.
 // - arena can be created using Clay_CreateArenaWithCapacityAndMemory()
 // - layoutDimensions are the initial bounding dimensions of the layout (i.e. the screen width and height for a full screen layout)
@@ -3696,6 +3699,12 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
             context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED_THIS_FRAME;
         }
     }
+}
+
+CLAY_WASM_EXPORT("Clay_GetPointerState")
+Clay_PointerData Clay_GetPointerState() {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return context->pointerInfo;
 }
 
 CLAY_WASM_EXPORT("Clay_Initialize")


### PR DESCRIPTION
Having pointer state access allows you to build flexible interactions and provide parity with what you can do with OnHover without needing OnHover. You can't use onHover if you want to return the result of your calculation. 

Currently you can get this through Clay_Context but many languages don't have access or need access to that internal data and use Clay_Context purely as a pointer/empty object. 