### PR TITLE
[Core] Make `CLAY_MIN` and `CLAY_MAX` aware of type and double eval

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -50,8 +50,8 @@
 
 // Public Macro API ------------------------
 
-#define CLAY__MAX(x, y) (((x) > (y)) ? (x) : (y))
-#define CLAY__MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define CLAY__MAX(x, y) (__typeof__ (x) _x = (x); __typeof__ (y) _y = (y); ((_x) > (_y)) ? (_x) : (_y))
+#define CLAY__MIN(x, y) (__typeof__ (x) _x = (x); __typeof__ (y) _y = (y); ((_x) < (_y)) ? (_x) : (_y))
 
 #define CLAY_TEXT_CONFIG(...) Clay__StoreTextElementConfig(CLAY__CONFIG_WRAPPER(Clay_TextElementConfig, __VA_ARGS__))
 

--- a/clay.h
+++ b/clay.h
@@ -50,8 +50,8 @@
 
 // Public Macro API ------------------------
 
-#define CLAY__MAX(x, y) (__typeof__ (x) _x = (x); __typeof__ (y) _y = (y); ((_x) > (_y)) ? (_x) : (_y))
-#define CLAY__MIN(x, y) (__typeof__ (x) _x = (x); __typeof__ (y) _y = (y); ((_x) < (_y)) ? (_x) : (_y))
+#define CLAY__MAX(x, y) ({__typeof__ (x) _x = (x); __typeof__ (y) _y = (y); ((_x) > (_y)) ? (_x) : (_y)})
+#define CLAY__MIN(x, y) ({__typeof__ (x) _x = (x); __typeof__ (y) _y = (y); ((_x) < (_y)) ? (_x) : (_y)})
 
 #define CLAY_TEXT_CONFIG(...) Clay__StoreTextElementConfig(CLAY__CONFIG_WRAPPER(Clay_TextElementConfig, __VA_ARGS__))
 


### PR DESCRIPTION
I tried to run the docker tests it failed for me before this change so im not sure how to test it on my system. 
Normal build with examples also fails because I'm on a wayland only system so I cant build any of the demos due to a X11 dependency in raylib I believe

I was going to make an issue but this change is very easy so I decided to open a PR being clear you are absolutely free to close this for any reason.

refer to 
https://stackoverflow.com/questions/3437404/min-and-max-in-c
https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Typeof.html#Typeof

It has a wrapper `{ }` which seems important (below is linked in the stack overflow)
https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html#Statement-Exprs
This fails to compile if you have `-Wpedantic` though even though it says you must use `__typeof__` in ISO C programs

Why is this useful?
The comment in the stack overflow, other gcc docs I linked can explain it better than I could. I just know this is typically the preferred method of defining a macro version of `min` and `max` in c


