### PR TITLE
[Bindings/Odin] expose _OpenElement and _CloseElement

### DIFF
--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -367,7 +367,7 @@ Context :: struct {} // opaque structure, only use as a pointer
 @(link_prefix = "Clay_", default_calling_convention = "c")
 foreign Clay {
 	_OpenElement :: proc() ---
-    _CloseElement :: proc() ---
+	_CloseElement :: proc() ---
 	MinMemorySize :: proc() -> u32 ---
 	CreateArenaWithCapacityAndMemory :: proc(capacity: u32, offset: [^]u8) -> Arena ---
 	SetPointerState :: proc(position: Vector2, pointerDown: bool) ---

--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -366,6 +366,8 @@ Context :: struct {} // opaque structure, only use as a pointer
 
 @(link_prefix = "Clay_", default_calling_convention = "c")
 foreign Clay {
+	_OpenElement :: proc() ---
+    _CloseElement :: proc() ---
 	MinMemorySize :: proc() -> u32 ---
 	CreateArenaWithCapacityAndMemory :: proc(capacity: u32, offset: [^]u8) -> Arena ---
 	SetPointerState :: proc(position: Vector2, pointerDown: bool) ---
@@ -398,9 +400,7 @@ foreign Clay {
 
 @(link_prefix = "Clay_", default_calling_convention = "c", private)
 foreign Clay {
-	_OpenElement :: proc() ---
 	_ConfigureOpenElement :: proc(config: ElementDeclaration) ---
-	_CloseElement :: proc() ---
 	_HashString :: proc(key: String, offset: u32, seed: u32) -> ElementId ---
 	_OpenTextElement :: proc(text: String, textConfig: ^TextElementConfig) ---
 	_StoreTextElementConfig :: proc(config: TextElementConfig) -> ^TextElementConfig ---


### PR DESCRIPTION
I guess `_OpenElement` and `_CloseElement` are considered private because in C you will likely always use the provided macro. In Odin however there are no macros and exposing the functions allows creating nice component procedures, i.e.:

```odin
@(deferred_none = clay._CloseElement)
my_button :: proc(id: clay.ElementId) -> bool {
	clay._OpenElement()
	return clay.ConfigureOpenElement({layout = {padding = clay.PaddingAll(8)}})
}
```

Which can be used like this (without calling the higher-order `clay.UI` function):

```odin
if my_button(clay.ID("Btn")) {
	clay.Text("Hellope", clay.TextConfig({textColor = WHITE}))
}

/// instead of:

// my_button would return just a clay.ElementDeclaration here
if clay.UI()(my_button(clay.ID("Btn"))) {
	clay.Text("Hellope", clay.TextConfig({textColor = WHITE}))
}
```