### PR TITLE
Add Clay_GetElementHovered with elementId

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -832,6 +832,8 @@ CLAY_DLL_EXPORT Clay_ElementData Clay_GetElementData(Clay_ElementId id);
 // Returns true if the pointer position provided by Clay_SetPointerState is within the current element's bounding box.
 // Works during element declaration, e.g. CLAY({ .backgroundColor = Clay_Hovered() ? BLUE : RED });
 CLAY_DLL_EXPORT bool Clay_Hovered(void);
+// Returns true if an element with the specified id is found and if the pointer position provided by Clay_SetPointerState is within the element's bounding box.
+CLAY_DLL_EXPORT bool Clay_GetElementHovered(Clay_ElementId elementId);
 // Bind a callback that will be called when the pointer position provided by Clay_SetPointerState is within the current element's bounding box.
 // - onHoverFunction is a function pointer to a user defined function.
 // - userData is a pointer that will be transparently passed through when the onHoverFunction is called.
@@ -3954,6 +3956,19 @@ bool Clay_Hovered(void) {
     }
     for (int32_t i = 0; i < context->pointerOverIds.length; ++i) {
         if (Clay__ElementIdArray_Get(&context->pointerOverIds, i)->id == openLayoutElement->id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Clay_GetElementHovered(Clay_ElementId elementId) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return false;
+    }
+    for (int32_t i = 0; i < context->pointerOverIds.length; ++i) {
+        if (Clay__ElementIdArray_Get(&context->pointerOverIds, i)->id == elementId.id) {
             return true;
         }
     }


### PR DESCRIPTION
This adds support for requesting status of element hover in case where element depend on each other.
This is a case from my code, where I added a sticky header for a table and wanted the scroll to work when hovering either of the elements.

```cpp
Clay_ElementId table_id = Clay_GetElementId(CLAY_STRING("table"));
Clay_ElementId header_id = Clay_GetElementId(CLAY_STRING("header"));

Clay_ScrollContainerData table_scroll_data = Clay_GetScrollContainerData(table_id);
Clay_ScrollContainerData header_scroll_data = Clay_GetScrollContainerData(header_id);

bool is_table_hovered = Clay_GetElementHovered(table_id);
bool is_header_hovered = Clay_GetElementHovered(header_id);

if (header_scroll_data.found && table_scroll_data.found) {
    if (is_table_hovered) {
        header_scroll_data.scrollPosition->x = table_scroll_data.scrollPosition->x;
    } else if (is_header_hovered) {
        table_scroll_data.scrollPosition->x = header_scroll_data.scrollPosition->x;
    }
}

```

