### PR TITLE
Adds CLAY_TEXT_ALIGN_SHRINK Option Which Allows Renderer to Decide How it Wants to Fit Text Into a Small Space

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -353,6 +353,8 @@ typedef CLAY_PACKED_ENUM {
     CLAY_TEXT_ALIGN_CENTER,
     // Horizontally aligns wrapped lines of text to the right hand side of their bounding box.
     CLAY_TEXT_ALIGN_RIGHT,
+    // The boundingBox passed to the TEXT render command may be smaller than the measured text size. The renderer must then decide how to shorten the text to make it fit
+    CLAY_TEXT_ALIGN_SHRINK,
 } Clay_TextAlignment;
 
 // Controls various functionality related to text elements.
@@ -2676,14 +2678,24 @@ void Clay__CalculateFinalLayout(void) {
                                     continue;
                                 }
                                 float offset = (currentElementBoundingBox.width - wrappedLine->dimensions.width);
-                                if (textElementConfig->textAlignment == CLAY_TEXT_ALIGN_LEFT) {
+                                if (textElementConfig->textAlignment == CLAY_TEXT_ALIGN_LEFT || textElementConfig->textAlignment == CLAY_TEXT_ALIGN_SHRINK) {
                                     offset = 0;
                                 }
                                 if (textElementConfig->textAlignment == CLAY_TEXT_ALIGN_CENTER) {
                                     offset /= 2;
                                 }
+                                Clay_BoundingBox textBoundingBox = {
+                                    currentElementBoundingBox.x + offset,
+                                    currentElementBoundingBox.y + yPosition,
+                                    wrappedLine->dimensions.width,
+                                    wrappedLine->dimensions.height
+                                };
+                                if (textElementConfig->textAlignment == CLAY_TEXT_ALIGN_SHRINK && boundingBox.width > currentElementBoundingBox.width) {
+                                    boundingBox.width = currentElementBoundingBox.width;
+                                }
                                 Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
                                     .boundingBox = { currentElementBoundingBox.x + offset, currentElementBoundingBox.y + yPosition, wrappedLine->dimensions.width, wrappedLine->dimensions.height },
+                                    .boundingBox = textBoundingBox,
                                     .renderData = { .text = {
                                         .stringContents = CLAY__INIT(Clay_StringSlice) { .length = wrappedLine->line.length, .chars = wrappedLine->line.chars, .baseChars = currentElement->childrenOrTextContent.textElementData->text.chars },
                                         .textColor = textElementConfig->textColor,


### PR DESCRIPTION
## Commit Description:
Adds `CLAY_TEXT_ALIGN_SHRINK` option to `Clay_TextAlignment` which tells the TEXT command producing code it is allowed to pass a boundingBox that is horizontally smaller than the result of the `MeasureText` call for that string. The Renderer is then able to choose how it wants to fit a piece of text in a smaller space (often this involves removing some number of characters and replacing them with "..." characters)

## Further Comments:
The current behavior does not expose the `currentElementBoundingBox` size when producing a `CLAY_RENDER_COMMAND_TYPE_TEXT` command. This means the Renderer implementation is not able to determine when text was unable to fit into the available space. By adding a new `ALIGN` option, we can disable the offset that is produced by attempting to align (same behavior as `CLAY_TEXT_ALIGN_LEFT`) and simultaneously use the `currentElementBoundingBox.width` rather than the `wrappedLine->dimensions.width` when the line is wider than the available space. This allows the renderer to decide how it should shorten the text in order to fit inside the bounding box specified in the command, potentially doing complex calculations that would be hard for Clay to perform itself (given that it's one option for interacting with the text layout is the `measureTextFunction`)

This commit does not contain edits to the existing renderers yet, and may be treated as more of a suggestion rather than a final pull request. This is only one way that the problem of fitting text into a smaller space could be solved, and I'll admit I don't love that a `ALIGN` option is being used for something that isn't exactly alignment. It's possible that this should be a separate option altogether, or maybe a new value for `Clay_TextElementConfigWrapMode` instead.

## Example GIF:
![file_path_contraction_example](https://github.com/user-attachments/assets/257e76bd-bef6-4e29-afd0-f4882e8a512d)
