### PR TITLE
[Renderers/Raylib] Support unicode in Raylib_MeasureText

### DIFF
--- a/renderers/raylib/clay_renderer_raylib.c
+++ b/renderers/raylib/clay_renderer_raylib.c
@@ -99,16 +99,22 @@ static inline Clay_Dimensions Raylib_MeasureText(Clay_StringSlice text, Clay_Tex
 
     float scaleFactor = config->fontSize/(float)fontToUse.baseSize;
 
-    for (int i = 0; i < text.length; ++i)
-    {
-        if (text.chars[i] == '\n') {
+    int byte_index = 0;
+    while (byte_index < text.length) {
+        if (text.chars[byte_index] == '\n') {
             maxTextWidth = fmax(maxTextWidth, lineTextWidth);
             lineTextWidth = 0;
+            byte_index++;
             continue;
         }
-        int index = text.chars[i] - 32;
-        if (fontToUse.glyphs[index].advanceX != 0) lineTextWidth += fontToUse.glyphs[index].advanceX;
-        else lineTextWidth += (fontToUse.recs[index].width + fontToUse.glyphs[index].offsetX);
+
+        int codepoint_bytes = 0;
+        int codepoint = GetCodepoint(&text.chars[byte_index], &codepoint_bytes);
+        int glyph_index = GetGlyphIndex(fontToUse, codepoint);
+        byte_index += codepoint_bytes;
+
+        if (fontToUse.glyphs[glyph_index].advanceX != 0) lineTextWidth += fontToUse.glyphs[glyph_index].advanceX;
+        else lineTextWidth += (fontToUse.recs[glyph_index].width + fontToUse.glyphs[glyph_index].offsetX);
     }
 
     maxTextWidth = fmax(maxTextWidth, lineTextWidth);


### PR DESCRIPTION
When running my code in Xcode with all sorts of sanitizers, I got the "Heap buffer overflow" error in a string containing unicode characters.

I noticed that the code did not support unicode correctly, so I copied an implementation of this loop from my own text renderer. It uses Raylib's `GetCodepoint` and `GetGlyphIndex` functions and makes no assumptions about the string structure.

My application uses a monospaced font, so I did not have a chance to test this other than running the 2 example raylib projects, which looked correct.