### PR TITLE
[Compilers] Fixed SIMD related compile error on some ARM compilers

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1769,7 +1769,7 @@ bool Clay__MemCmp(const char *s1, const char *s2, int32_t length);
             uint8x16_t v2 = vld1q_u8((const uint8_t *)s2);
 
             // Compare vectors
-            if (vminvq_u32(vceqq_u8(v1, v2)) != 0xFFFFFFFF) { // If there's a difference
+            if (vminvq_u32(vreinterpretq_u32_u8(vceqq_u8(v1, v2))) != 0xFFFFFFFF) { // If there's a difference
                 return false;
             }
 


### PR DESCRIPTION
When compiling for arm using GCC it would complain about the following code because the argument wasn't correct for `vminq_u32` I have now added a cast (that just reinterprets the type so no overhead) to fix the compile error.