### PR TITLE
[Renderers/SDL2] Added explicit include of math.h in SDL2 renderer

### DIFF
--- a/renderers/SDL2/clay_renderer_SDL2.c
+++ b/renderers/SDL2/clay_renderer_SDL2.c
@@ -3,6 +3,7 @@
 #include <SDL_ttf.h>
 #include <SDL_image.h>
 #include <stdio.h>
+#include <math.h>
 
 #ifndef M_PI
     #define M_PI 3.14159


### PR DESCRIPTION
GCC Complaining about not including math.h still runs without the include, but a wall of "use math.h" is printed