### PR TITLE
Add interface target to be used with Meson's CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,3 +38,6 @@ if(NOT MSVC AND (CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_SDL3_EXAMPLES))
 endif()
 
 #  add_subdirectory("examples/cairo-pdf-rendering") Some issue with github actions populating cairo, disable for now
+
+add_library(headers INTERFACE)
+target_include_directories(headers INTERFACE .)


### PR DESCRIPTION
Add an INTERFACE library target so that Clay can be used as a subproject within Meson, instead of having to be hard linked within the sources / CFLAGS.

The target won't produce any file artifacts while allowing you to register of a dependency with `<clay_cmake_subproject>.dependency('headers')`

This helps modularize Meson projects which depend on Clay and minimizes bloat by not requiring users to create an additional directory for dependencies.