### PR TITLE
[Cmake] Basic CMake support for easier import into CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,3 +38,6 @@ if(NOT MSVC AND (CLAY_INCLUDE_ALL_EXAMPLES OR CLAY_INCLUDE_SDL3_EXAMPLES))
 endif()
 
 #  add_subdirectory("examples/cairo-pdf-rendering") Some issue with github actions populating cairo, disable for now
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE .)


### PR DESCRIPTION
This PR will allow to use library in a manner provided below:
```
set(CLAY_INCLUDE_ALL_EXAMPLES OFF)
FetchContent_Declare(
	CLAY
	GIT_REPOSITORY "https://github.com/Qualadia/clay.git"
	GIT_TAG main
	GIT_SHALLOW TRUE
	GIT_PROGRESS TRUE
)
FetchContent_MakeAvailable(CLAY)

target_link_libraries(${PROJECT_NAME} PRIVATE
	clay
)
```
