### PR TITLE
Fix CLAY__ELEMENT_DEFINITION_LATCH overflow in CLAY macro if 256 loops end at the same time

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -132,7 +132,7 @@ static uint8_t CLAY__ELEMENT_DEFINITION_LATCH;
     for (                                                                                                                                                   \
         CLAY__ELEMENT_DEFINITION_LATCH = (Clay__OpenElement(), Clay__ConfigureOpenElement(CLAY__CONFIG_WRAPPER(Clay_ElementDeclaration, __VA_ARGS__)), 0);  \
         CLAY__ELEMENT_DEFINITION_LATCH < 1;                                                                                                                 \
-        ++CLAY__ELEMENT_DEFINITION_LATCH, Clay__CloseElement()                                                                                              \
+        CLAY__ELEMENT_DEFINITION_LATCH=1, Clay__CloseElement()                                                                                              \
     )
 
 // These macros exist to allow the CLAY() macro to be called both with an inline struct definition, such as


### PR DESCRIPTION
Incrementing the `CLAY__ELEMENT_DEFINITION_LATCH` in the post-for-loop logic can cause undesired effects if it gets incremented 256 times in a row. This only happens if 256 `CLAY` scopes end in a row without another CLAY scope starting.

To fix this, we can simply set `CLAY__ELEMENT_DEFINITION_LATCH=1` rather than incrementing it.