### PR TITLE
[Bindings/Odin] Remove field hashStringContents in odin bindings

### DIFF
--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -111,7 +111,6 @@ TextElementConfig :: struct {
 	lineHeight:         u16,
 	wrapMode:           TextWrapMode,
 	textAlignment:      TextAlignment,
-	hashStringContents: bool,
 }
 
 ImageElementConfig :: struct {


### PR DESCRIPTION
PR  #335 removed this field in clay.h but the bindings didn't reflect that change