### PR TITLE
[Core] Fix a string hash bug with single characters

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1392,6 +1392,7 @@ uint64_t Clay__HashData(const uint8_t* data, size_t length) {
     Clay__SIMDARXMix(&v2, &v3);
     v0 = _mm_add_epi64(v0, v2);
     v1 = _mm_add_epi64(v1, v3);
+    v0 = _mm_add_epi64(v0, v1);
 
     uint64_t result[2];
     _mm_storeu_si128((__m128i*)result, v0);
@@ -1445,6 +1446,7 @@ uint64_t Clay__HashData(const uint8_t* data, size_t length) {
     Clay__SIMDARXMix(&v2, &v3);
     v0 = vaddq_u64(v0, v2);
     v1 = vaddq_u64(v1, v3);
+    v0 = vaddq_u64(v0, v1);
 
     uint64_t result[2];
     vst1q_u64(result, v0);

--- a/examples/sokol-video-demo/CMakeLists.txt
+++ b/examples/sokol-video-demo/CMakeLists.txt
@@ -22,7 +22,7 @@ FetchContent_MakeAvailable(fontstash)
 FetchContent_Declare(
     sokol
     GIT_REPOSITORY "https://github.com/floooh/sokol.git"
-    GIT_TAG "da9de496f938b7575eff7f01ab774d77469bd390"
+    GIT_TAG "master"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )


### PR DESCRIPTION
This is a reasonably temporary fix for single character text hashes - we'll replace the entire hash function with something like [meowhash](https://github.com/cmuratori/meow_hash) in the near future.