### PR TITLE
[Renderers/SDL3] Use `SDL_Texture` instead of `SDL_Surface` for images

### DIFF
--- a/examples/SDL3-simple-demo/main.c
+++ b/examples/SDL3-simple-demo/main.c
@@ -24,6 +24,7 @@ typedef struct app_state {
 } AppState;
 
 SDL_Texture *sample_image;
+bool show_demo = true;
 
 static inline Clay_Dimensions SDL_MeasureText(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData)
 {
@@ -41,6 +42,42 @@ static inline Clay_Dimensions SDL_MeasureText(Clay_StringSlice text, Clay_TextEl
 void HandleClayErrors(Clay_ErrorData errorData) {
     printf("%s", errorData.errorText.chars);
 }
+
+
+Clay_RenderCommandArray ClayImageSample_CreateLayout() {
+    Clay_BeginLayout();
+
+    Clay_Sizing layoutExpand = {
+        .width = CLAY_SIZING_GROW(0),
+        .height = CLAY_SIZING_GROW(0)
+    };
+
+    CLAY({ .id = CLAY_ID("OuterContainer"),
+        .layout = {
+            .layoutDirection = CLAY_TOP_TO_BOTTOM,
+            .sizing = layoutExpand,
+            .padding = CLAY_PADDING_ALL(16),
+            .childGap = 16
+        }
+    }) {
+        CLAY({
+            .id = CLAY_ID("SampleImage"),
+            .layout = {
+                .sizing = layoutExpand
+            },
+            .image = {
+                .imageData = sample_image,
+                .sourceDimensions = {
+                    .width = 23,
+                    .height = 42
+                },
+            }
+        });
+    }
+
+    return Clay_EndLayout();
+}
+
 
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 {
@@ -115,6 +152,11 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
         case SDL_EVENT_QUIT:
             ret_val = SDL_APP_SUCCESS;
             break;
+        case SDL_EVENT_KEY_UP:
+            if (event->key.scancode == SDL_SCANCODE_SPACE) {
+                show_demo = !show_demo;
+            }
+            break;
         case SDL_EVENT_WINDOW_RESIZED:
             Clay_SetLayoutDimensions((Clay_Dimensions) { (float) event->window.data1, (float) event->window.data2 });
             break;
@@ -140,7 +182,10 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 {
     AppState *state = appstate;
 
-    Clay_RenderCommandArray render_commands = ClayVideoDemo_CreateLayout(&state->demoData);
+    Clay_RenderCommandArray render_commands = (show_demo
+        ? ClayVideoDemo_CreateLayout(&state->demoData)
+        : ClayImageSample_CreateLayout()
+    );
 
     SDL_SetRenderDrawColor(state->rendererData.renderer, 0, 0, 0, 255);
     SDL_RenderClear(state->rendererData.renderer);

--- a/examples/SDL3-simple-demo/main.c
+++ b/examples/SDL3-simple-demo/main.c
@@ -23,7 +23,7 @@ typedef struct app_state {
     ClayVideoDemo_Data demoData;
 } AppState;
 
-SDL_Surface *sample_image;
+SDL_Texture *sample_image;
 
 static inline Clay_Dimensions SDL_MeasureText(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData)
 {
@@ -83,7 +83,11 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     state->rendererData.fonts[FONT_ID] = font;
 
-    sample_image = IMG_Load("resources/sample.png");
+    sample_image = IMG_LoadTexture(state->rendererData.renderer, "resources/sample.png");
+    if (!sample_image) {
+        SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Failed to load image: %s", SDL_GetError());
+        return SDL_APP_FAILURE;
+    }
 
     /* Initialize Clay */
     uint64_t totalMemorySize = Clay_MinMemorySize();
@@ -157,6 +161,10 @@ void SDL_AppQuit(void *appstate, SDL_AppResult result)
     }
 
     AppState *state = appstate;
+
+    if (sample_image) {
+        SDL_DestroyTexture(sample_image);
+    }
 
     if (state) {
         if (state->rendererData.renderer)

--- a/renderers/SDL3/clay_renderer_SDL3.c
+++ b/renderers/SDL3/clay_renderer_SDL3.c
@@ -251,12 +251,9 @@ static void SDL_Clay_RenderClayCommands(Clay_SDL3RendererData *rendererData, Cla
                 break;
             }
             case CLAY_RENDER_COMMAND_TYPE_IMAGE: {
-                SDL_Surface *image = (SDL_Surface *)rcmd->renderData.image.imageData;
-                SDL_Texture *texture = SDL_CreateTextureFromSurface(rendererData->renderer, image);
+                SDL_Texture *texture = (SDL_Texture *)rcmd->renderData.image.imageData;
                 const SDL_FRect dest = { rect.x, rect.y, rect.w, rect.h };
-
                 SDL_RenderTexture(rendererData->renderer, texture, NULL, &dest);
-                SDL_DestroyTexture(texture);
                 break;
             }
             default:


### PR DESCRIPTION
# Context

At the moment, the SDL3 renderer image feature is very inefficient. It expects in `imageData` an `SDL_Surface*`, and then creates an `SDL_Texture*` that is immediately destroyed.

Creating an `SDL_Texture*` every single frame is very inefficient and can kill the framerate. This operation uploads the image data to the GPU, which is a rather slow operation. You usually want to do that only once.

# Changes

 - Modify the image rendering feature so that `imageData` expects an `SDL_Texture*` instead of a `SDL_Surface*`
 - Update the SDL3 example to load the sample image as a texture instead of a surface
 - Add an example of how to display an image using clay that is not present in the shared layout