### PR TITLE
[CMake] Remove redundant debug & release flag variable definitions

### DIFF
--- a/examples/SDL2-video-demo/CMakeLists.txt
+++ b/examples/SDL2-video-demo/CMakeLists.txt
@@ -44,13 +44,6 @@ target_link_libraries(SDL2_video_demo PUBLIC
     SDL2_image::SDL2_image-static
 )
 
-if(MSVC)
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-else()
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-endif()
-
 add_custom_command(
         TARGET SDL2_video_demo POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/examples/SDL3-simple-demo/CMakeLists.txt
+++ b/examples/SDL3-simple-demo/CMakeLists.txt
@@ -4,9 +4,6 @@ cmake_minimum_required(VERSION 3.27)
 project(clay_examples_sdl3_simple_demo C)
 set(CMAKE_C_STANDARD 99)
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-
 include(FetchContent)
 set(FETCHCONTENT_QUIET FALSE)
 

--- a/examples/cairo-pdf-rendering/CMakeLists.txt
+++ b/examples/cairo-pdf-rendering/CMakeLists.txt
@@ -12,8 +12,6 @@ target_compile_options(clay_examples_cairo_pdf_rendering PUBLIC)
 target_include_directories(clay_examples_cairo_pdf_rendering PUBLIC . ${CAIRO_INCLUDE_DIRS})
 
 target_link_libraries(clay_examples_cairo_pdf_rendering PUBLIC Cairo::Cairo)
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
 add_custom_command(
         TARGET clay_examples_cairo_pdf_rendering POST_BUILD

--- a/examples/cpp-project-example/CMakeLists.txt
+++ b/examples/cpp-project-example/CMakeLists.txt
@@ -9,8 +9,3 @@ endif()
 add_executable(clay_examples_cpp_project_example main.cpp)
 
 target_include_directories(clay_examples_cpp_project_example PUBLIC .)
-
-if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-endif()

--- a/examples/introducing-clay-video-demo/CMakeLists.txt
+++ b/examples/introducing-clay-video-demo/CMakeLists.txt
@@ -27,9 +27,6 @@ target_link_libraries(clay_examples_introducing_clay_video_demo PUBLIC raylib)
 
 if(MSVC)
   set(CMAKE_C_FLAGS_DEBUG "/D CLAY_DEBUG")
-else()
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 endif()
 
 add_custom_command(

--- a/examples/raylib-multi-context/CMakeLists.txt
+++ b/examples/raylib-multi-context/CMakeLists.txt
@@ -25,9 +25,6 @@ target_include_directories(clay_examples_raylib_multi_context PUBLIC .)
 
 target_link_libraries(clay_examples_raylib_multi_context PUBLIC raylib)
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-
 add_custom_command(
         TARGET clay_examples_raylib_multi_context POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/examples/raylib-sidebar-scrolling-container/CMakeLists.txt
+++ b/examples/raylib-sidebar-scrolling-container/CMakeLists.txt
@@ -24,12 +24,6 @@ target_compile_options(clay_examples_raylib_sidebar_scrolling_container PUBLIC)
 target_include_directories(clay_examples_raylib_sidebar_scrolling_container PUBLIC .)
 
 target_link_libraries(clay_examples_raylib_sidebar_scrolling_container PUBLIC raylib)
-if(MSVC)
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-else()
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-endif()
 
 add_custom_command(
         TARGET clay_examples_raylib_sidebar_scrolling_container POST_BUILD


### PR DESCRIPTION
At one point these commands were injecting additional flags, but now it looks like they define a variable as itself (presumably to no effect?).

Two more files also have some unusual flags, but I'm less confident that removing them won't have unexpected side-effects so I haven't touched them in this PR:
https://github.com/nicbarker/clay/blob/ce2475ba739c04938616d59e6048a1355f4fdd06/examples/terminal-example/CMakeLists.txt#L14-L15

https://github.com/nicbarker/clay/blob/ce2475ba739c04938616d59e6048a1355f4fdd06/examples/introducing-clay-video-demo/CMakeLists.txt#L29