### PR TITLE
[Core] Fix dimension calculation that would always result in 0

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1781,7 +1781,7 @@ void Clay__UpdateAspectRatioBox(Clay_LayoutElement *layoutElement) {
             if (layoutElement->dimensions.width == 0 && layoutElement->dimensions.height != 0) {
                 layoutElement->dimensions.width = layoutElement->dimensions.height * aspectConfig->aspectRatio;
             } else if (layoutElement->dimensions.width != 0 && layoutElement->dimensions.height == 0) {
-                layoutElement->dimensions.height = layoutElement->dimensions.height * (1 / aspectConfig->aspectRatio);
+                layoutElement->dimensions.height = layoutElement->dimensions.width * (1 / aspectConfig->aspectRatio);
             }
             break;
         }


### PR DESCRIPTION
Very minor issue I just noticed. I've never done open source contribution, so let me know if this is an acceptable way to go about it.

Given that the line `if (layoutElement->dimensions.width != 0 && layoutElement->dimensions.height == 0)` is checking if the height of the layout element is 0, it didn't make sense to me to multiply the height by `1/aspect` because the result would always be 0 anyway, hence my change from "height" to "width".