### PR TITLE
Odin binding: removed comptime from text parameter

### DIFF
--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -430,7 +430,7 @@ UI :: proc() -> proc (config: ElementDeclaration) -> bool {
 	return ConfigureOpenElement
 }
 
-Text :: proc($text: string, config: ^TextElementConfig) {
+Text :: proc(text: string, config: ^TextElementConfig) {
 	wrapped := MakeString(text)
 	wrapped.isStaticallyAllocated = true
 	_OpenTextElement(wrapped, config)


### PR DESCRIPTION
Originally in bindings we have 