### PR TITLE
Report error message via log interface when out of space

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4201,6 +4201,10 @@ Clay_RenderCommandArray Clay_EndLayout(void) {
         } else {
             message = CLAY_STRING("Clay Error: Layout elements exceeded Clay__maxElementCount");
         }
+        context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+                .errorText = message,
+                .userData = context->errorHandler.userData });
         Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand ) {
             .boundingBox = { context->layoutDimensions.width / 2 - 59 * 4, context->layoutDimensions.height / 2, 0, 0 },
             .renderData = { .text = { .stringContents = CLAY__INIT(Clay_StringSlice) { .length = message.length, .chars = message.chars, .baseChars = message.chars }, .textColor = {255, 0, 0, 255}, .fontSize = 16 } },
@@ -4365,7 +4369,7 @@ void Clay_ResetMeasureTextCache(void) {
     context->measureTextHashMap.length = 0;
     context->measuredWords.length = 0;
     context->measuredWordsFreeList.length = 0;
-    
+
     for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
         context->measureTextHashMap.internalArray[i] = 0;
     }


### PR DESCRIPTION
When the debug window render commands are inserted into the render command list, there's a possibility to run out of elements. The error for this case was only drawn on screen, but not reported through the log interface. This PR fixes this.