### PR TITLE
[Bug Fix] Multiple Floating Elements Cannot Use `Clay_Hovered()`

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1141,6 +1141,7 @@ typedef struct {
         Clay__LayoutElementChildren children;
         Clay__TextElementData *textElementData;
     } childrenOrTextContent;
+    uint16_t floatingChildrenCount;
     Clay_Dimensions dimensions;
     Clay_Dimensions minDimensions;
     Clay_LayoutConfig *layoutConfig;
@@ -1776,7 +1777,8 @@ Clay_LayoutElementHashMapItem *Clay__GetHashMapItem(uint32_t id) {
 Clay_ElementId Clay__GenerateIdForAnonymousElement(Clay_LayoutElement *openLayoutElement) {
     Clay_Context* context = Clay_GetCurrentContext();
     Clay_LayoutElement *parentElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 2));
-    Clay_ElementId elementId = Clay__HashNumber(parentElement->childrenOrTextContent.children.length, parentElement->id);
+    uint32_t offset = parentElement->childrenOrTextContent.children.length + parentElement->floatingChildrenCount;
+    Clay_ElementId elementId = Clay__HashNumber(offset, parentElement->id);
     openLayoutElement->id = elementId.id;
     Clay__AddHashMapItem(elementId, openLayoutElement);
     Clay__StringArray_Add(&context->layoutElementIdStrings, elementId.stringId);
@@ -1917,9 +1919,15 @@ void Clay__CloseElement(void) {
 
     // Close the currently open element
     int32_t closingElementIndex = Clay__int32_tArray_RemoveSwapback(&context->openLayoutElementStack, (int)context->openLayoutElementStack.length - 1);
+
+    // Get the currently open parent
     openLayoutElement = Clay__GetOpenLayoutElement();
 
-    if (!elementIsFloating && context->openLayoutElementStack.length > 1) {
+    if (context->openLayoutElementStack.length > 1) {
+        if(elementIsFloating) {
+            openLayoutElement->floatingChildrenCount++;
+            return;
+        }
         openLayoutElement->childrenOrTextContent.children.length++;
         Clay__int32_tArray_Add(&context->layoutElementChildrenBuffer, closingElementIndex);
     }
@@ -4410,7 +4418,7 @@ void Clay_ResetMeasureTextCache(void) {
     context->measureTextHashMap.length = 0;
     context->measuredWords.length = 0;
     context->measuredWordsFreeList.length = 0;
-    
+
     for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
         context->measureTextHashMap.internalArray[i] = 0;
     }
@@ -4444,3 +4452,4 @@ freely, subject to the following restrictions:
     3. This notice may not be removed or altered from any source
     distribution.
 */
+

--- a/clay.h
+++ b/clay.h
@@ -4418,7 +4418,7 @@ void Clay_ResetMeasureTextCache(void) {
     context->measureTextHashMap.length = 0;
     context->measuredWords.length = 0;
     context->measuredWordsFreeList.length = 0;
-
+    
     for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
         context->measureTextHashMap.internalArray[i] = 0;
     }
@@ -4452,4 +4452,3 @@ freely, subject to the following restrictions:
     3. This notice may not be removed or altered from any source
     distribution.
 */
-

--- a/clay.h
+++ b/clay.h
@@ -1141,12 +1141,12 @@ typedef struct {
         Clay__LayoutElementChildren children;
         Clay__TextElementData *textElementData;
     } childrenOrTextContent;
-    uint16_t floatingChildrenCount;
     Clay_Dimensions dimensions;
     Clay_Dimensions minDimensions;
     Clay_LayoutConfig *layoutConfig;
     Clay__ElementConfigArraySlice elementConfigs;
     uint32_t id;
+    uint16_t floatingChildrenCount;
 } Clay_LayoutElement;
 
 CLAY__ARRAY_DEFINE(Clay_LayoutElement, Clay_LayoutElementArray)


### PR DESCRIPTION
Summary from issue [#459](https://github.com/nicbarker/clay/issues/459): If a parent element has multiple floating children, then each child cannot use `Clay_Hovered()` because Clay will report an error, and hovering won't be handled properly.
```
An element with this ID was already previously declared during this layout.
```
I've found that `Clay_Hovered()` uses an anonymous ID for each button, generated from the amount of sibling elements as the offset. However, since floating children are not logically part of their parents, their IDs will not be unique.

My fix makes an element keep track of how many floating children they have to ensure generated anonymous IDs remains unique for each floating child.

https://github.com/user-attachments/assets/4624968c-e5dc-4018-8943-df50e71f0f2a

