### PR TITLE
[Renderers/Sokol] allow usage of images with sokol renderer

### DIFF
--- a/renderers/sokol/sokol_clay.h
+++ b/renderers/sokol/sokol_clay.h
@@ -95,7 +95,7 @@
         sclay_image to the CLAY macro, like this:
                 CLAY({
                    ...
-                   .image = { .imageData = &(sclay_image){ .image = img, .sampler = 0 } },
+                   .image = { .imageData = &(sclay_image){ .view = view, .sampler = 0 } },
                 })
         Using 0 as a sampler uses the sokol default sampler with linear interpolation.
         The image should be created using sg_make_image from sokol_gfx.
@@ -111,7 +111,7 @@
 typedef int sclay_font_t;
 
 typedef struct sclay_image {
-    sg_image image;
+    sg_view view;
     sg_sampler sampler;
     struct {
         float u0, v0, u1, v1;
@@ -459,7 +459,7 @@ void sclay_render(Clay_RenderCommandArray renderCommands, sclay_font_t *fonts) {
                 Clay_CornerRadius r = config->cornerRadius;
 
                 sgl_enable_texture();
-                sgl_texture(img->image, img->sampler);
+                sgl_texture(img->view, img->sampler);
 
                 sgl_begin_triangle_strip();
                 if(r.topLeft > 0 || r.topRight > 0){


### PR DESCRIPTION
This code implements the rendering of clay images for the sokol renderer backend.

Previously there was a big todo and the code did nothing. Now it renders the image.

Several caveats :

- I’m not that smart, so I just copy pasted the code to render rectangles and adapted it to provide uv coordinates to a texture. Any bug in the rectangle rendering will be in the image rendering.
- I tried to implement corner radius but couldn’t. Maybe someone smarter than me can figure it out (I might give it a try in the future). So if any cornerRadius is specified, the image will look quite bad. Maybe we should just render a full rectangle all the time instead of a corrupted image ?
- Yet, this is strictly better than before.
- Tinting worked out of the box, which I’m quite happy with.
- I tried to give a good explanation in the comment header, but English is not my first language, so any feedback is appreciated.
- Thanks for the awesome library.