### PR TITLE
[Renderers/Odin] Fix utf8 code points in example odin raylib renderer

### DIFF
--- a/bindings/odin/examples/clay-official-website/clay_renderer_raylib.odin
+++ b/bindings/odin/examples/clay-official-website/clay_renderer_raylib.odin
@@ -206,4 +206,4 @@ draw_rect :: proc(x, y, w, h: f32, color: clay.Color) {
 @(private = "file")
 draw_rect_rounded :: proc(x,y,w,h: f32, radius: f32, color: clay.Color){
     rl.DrawRectangleRounded({x,y,w,h},radius,8,clay_color_to_rl_color(color))
-} 
+}


### PR DESCRIPTION
I came across this issue (https://github.com/nicbarker/clay/issues/458) when using fonts from the Fluent icons (https://github.com/microsoft/fluentui-system-icons). These have code points somewhere in the 0xF800 range and measure text was returning an invalid width.

This PR is my attempt to port the fix to Odin. I'm new to the language so would value someone with a bit more experience  double checking the approach and style. In github there appears to be a change on the last line of the file -  I've made various attempts to resolve it and I can't see any change locally so I'm unsure if this is valid. 

