### PR TITLE
clay.h: Fix struct with default initializer not using CLAY__DEFAULT_STRUCT

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1659,7 +1659,7 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
         char current = text->chars[end];
         if (current == ' ' || current == '\n') {
             int32_t length = end - start;
-            Clay_Dimensions dimensions = {};
+            Clay_Dimensions dimensions = CLAY__DEFAULT_STRUCT;
             if (length > 0) {
                 dimensions = Clay__MeasureText(CLAY__INIT(Clay_StringSlice) {.length = length, .chars = &text->chars[start], .baseChars = text->chars}, config, context->measureTextUserData);
             }


### PR DESCRIPTION
clay.h: Fix struct with default initializer not using CLAY__DEFAULT_STRUCT
no other changes