### PR TITLE
Check flags availability for sanitization

### DIFF
--- a/examples/cpp-project-example/CMakeLists.txt
+++ b/examples/cpp-project-example/CMakeLists.txt
@@ -2,9 +2,19 @@ cmake_minimum_required(VERSION 3.27)
 project(clay_examples_cpp_project_example CXX)
 
 set(CMAKE_CXX_STANDARD 20)
-if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -g")
-endif()
+
+macro(add_checked_flag FLAG)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("${FLAG}" SUPPORTED)
+  if(SUPPORTED)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+  else()
+    message(WARNING "${FLAG} not supported")
+  endif()
+endmacro()
+
+add_checked_flag("-fsanitize=address")
+add_checked_flag("-fno-omit-frame-pointer")
 
 add_executable(clay_examples_cpp_project_example main.cpp)
 


### PR DESCRIPTION
When building examples with  GCC 14.3.1 on Fedora 41, I got an link error with libasan
I don't know why these flags were added in the first place but with this commit, they will be added only when availables.