### PR TITLE
Add separate rounded corners for SDL2 and SDL3

### DIFF
--- a/renderers/SDL2/clay_renderer_SDL2.c
+++ b/renderers/SDL2/clay_renderer_SDL2.c
@@ -44,7 +44,7 @@ static Clay_Dimensions SDL2_MeasureText(Clay_StringSlice text, Clay_TextElementC
 static int NUM_CIRCLE_SEGMENTS = 16;
 
 //all rendering is performed by a single SDL call, avoiding multiple RenderRect + plumbing choice for circles.
-static void SDL_RenderFillRoundedRect(SDL_Renderer* renderer, const SDL_FRect rect, const float cornerRadius, const Clay_Color _color) {
+static void SDL_RenderFillRoundedRect(SDL_Renderer* renderer, const SDL_FRect rect, const Clay_CornerRadius cornerRadius, const Clay_Color _color) {
     const SDL_Color color = (SDL_Color) {
             .r = (Uint8)_color.r,
             .g = (Uint8)_color.g,
@@ -54,48 +54,83 @@ static void SDL_RenderFillRoundedRect(SDL_Renderer* renderer, const SDL_FRect re
 
     int indexCount = 0, vertexCount = 0;
 
-    const float maxRadius = SDL_min(rect.w, rect.h) / 2.0f;
-    const float clampedRadius = SDL_min(cornerRadius, maxRadius);
+    enum corner_e {
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_RIGHT,
+        BOTTOM_LEFT,
+    };
 
-    const int numCircleSegments = SDL_max(NUM_CIRCLE_SEGMENTS, (int)clampedRadius * 0.5f);
+    const float maxRadius = SDL_min(rect.w, rect.h) / 2.f;
+    const float clampedRadius[4] = {
+        SDL_min(cornerRadius.topLeft, maxRadius),
+        SDL_min(cornerRadius.topRight, maxRadius),
+        SDL_min(cornerRadius.bottomRight, maxRadius),
+        SDL_min(cornerRadius.bottomLeft, maxRadius),
+    };
 
-    SDL_Vertex vertices[512];
-    int indices[512];
+    int numCircleSegments[4];
+    int totalVertices = 4 + 4 + 4*4;
+    int totalIndices = 6 + 6*4;
+    for(unsigned i = 0; i < 4; i++) {
+        const int n = SDL_max(NUM_CIRCLE_SEGMENTS, (int) clampedRadius[i] * 0.5f);
+        numCircleSegments[i] = n;
+        totalVertices += n * 2;
+        totalIndices += n * 3;
+    }
+
+    SDL_Vertex* vertices = SDL_malloc(totalVertices * sizeof(SDL_Vertex));
+    int* indices = SDL_malloc(totalIndices * sizeof(int));
+
+    const float innerLeft = rect.x + SDL_max(clampedRadius[TOP_LEFT], clampedRadius[BOTTOM_LEFT]);
+    const float innerTop = rect.y + SDL_max(clampedRadius[TOP_LEFT], clampedRadius[TOP_RIGHT]);
+    const float innerRight = rect.x + rect.w - SDL_max(clampedRadius[TOP_RIGHT], clampedRadius[BOTTOM_RIGHT]);
+    const float innerBottom = rect.y + rect.h - SDL_max(clampedRadius[BOTTOM_RIGHT], clampedRadius[BOTTOM_LEFT]);
 
     //define center rectangle
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + clampedRadius, rect.y + clampedRadius}, color, {0, 0} }; //0 center TL
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w - clampedRadius, rect.y + clampedRadius}, color, {1, 0} }; //1 center TR
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w - clampedRadius, rect.y + rect.h - clampedRadius}, color, {1, 1} }; //2 center BR
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + clampedRadius, rect.y + rect.h - clampedRadius}, color, {0, 1} }; //3 center BL
+    const int rectIndices[6] = {3, 0, 1, 2, 3, 1};
+    for (int i = 0; i < 6; i++)
+        indices[indexCount++] = rectIndices[i];
 
-    indices[indexCount++] = 0;
-    indices[indexCount++] = 1;
-    indices[indexCount++] = 3;
-    indices[indexCount++] = 1;
-    indices[indexCount++] = 2;
-    indices[indexCount++] = 3;
+    vertices[vertexCount++] = (SDL_Vertex){ {innerLeft, innerTop}, color, {0, 0} }; //0 center TL
+    vertices[vertexCount++] = (SDL_Vertex){ {innerRight, innerTop}, color, {1, 0} }; //1 center TR
+    vertices[vertexCount++] = (SDL_Vertex){ {innerRight, innerBottom}, color, {1, 1} }; //2 center BR
+    vertices[vertexCount++] = (SDL_Vertex){ {innerLeft, innerBottom}, color, {0, 1} }; //3 center BL
+
+    const SDL_FPoint cornerCenter[4] = {
+        { rect.x + clampedRadius[TOP_LEFT], rect.y + clampedRadius[TOP_LEFT] },
+        { rect.x + rect.w - clampedRadius[TOP_RIGHT], rect.y + clampedRadius[TOP_RIGHT]}, 
+        { rect.x + rect.w - clampedRadius[BOTTOM_RIGHT], rect.y + rect.h - clampedRadius[BOTTOM_RIGHT] },
+        { rect.x + clampedRadius[BOTTOM_LEFT], rect.y + rect.h - clampedRadius[BOTTOM_LEFT]},
+    };
+
+    //define corner centers
+    vertices[vertexCount++] = (SDL_Vertex){ cornerCenter[TOP_LEFT], color, {0, 0} };
+    vertices[vertexCount++] = (SDL_Vertex){ cornerCenter[TOP_RIGHT], color, {0, 0} };
+    vertices[vertexCount++] = (SDL_Vertex){ cornerCenter[BOTTOM_RIGHT], color, {0, 0} };
+    vertices[vertexCount++] = (SDL_Vertex){ cornerCenter[BOTTOM_LEFT], color, {0, 0} };
 
     //define rounded corners as triangle fans
-    const float step = (M_PI / 2) / numCircleSegments;
-    for (int i = 0; i < numCircleSegments; i++) {
-        const float angle1 = (float)i * step;
-        const float angle2 = ((float)i + 1.0f) * step;
+    for (int i = 0; i < 4; i++) {  // Iterate over four corners
+        const float step = (M_PI/2) / numCircleSegments[i];
+        SDL_FPoint signedRadius;
 
-        for (int j = 0; j < 4; j++) {  // Iterate over four corners
-            float cx, cy, signX, signY;
-
-            switch (j) {
-            case 0: cx = rect.x + clampedRadius; cy = rect.y + clampedRadius; signX = -1; signY = -1; break; // Top-left
-            case 1: cx = rect.x + rect.w - clampedRadius; cy = rect.y + clampedRadius; signX = 1; signY = -1; break; // Top-right
-            case 2: cx = rect.x + rect.w - clampedRadius; cy = rect.y + rect.h - clampedRadius; signX = 1; signY = 1; break; // Bottom-right
-            case 3: cx = rect.x + clampedRadius; cy = rect.y + rect.h - clampedRadius; signX = -1; signY = 1; break; // Bottom-left
+        switch (i) {
+            case TOP_LEFT: signedRadius = (SDL_FPoint){ -clampedRadius[i], -clampedRadius[i]}; break; // Top-left
+            case TOP_RIGHT: signedRadius = (SDL_FPoint){ clampedRadius[i], -clampedRadius[i]}; break; // Top-right
+            case BOTTOM_RIGHT: signedRadius = (SDL_FPoint){ clampedRadius[i], clampedRadius[i]}; break; // Bottom-right
+            case BOTTOM_LEFT: signedRadius = (SDL_FPoint){ -clampedRadius[i], clampedRadius[i]}; break; // Bottom-left
             default: return;
-            }
+        }
 
-            vertices[vertexCount++] = (SDL_Vertex){ {cx + SDL_cosf(angle1) * clampedRadius * signX, cy + SDL_sinf(angle1) * clampedRadius * signY}, color, {0, 0} };
-            vertices[vertexCount++] = (SDL_Vertex){ {cx + SDL_cosf(angle2) * clampedRadius * signX, cy + SDL_sinf(angle2) * clampedRadius * signY}, color, {0, 0} };
+        for (int j = 0; j < numCircleSegments[i]; j++) {
+            const float angle1 = (float)j * step;
+            const float angle2 = ((float)j + 1.0f) * step;
 
-            indices[indexCount++] = j;  // Connect to corresponding central rectangle vertex
+            vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[i].x + SDL_cosf(angle1) * signedRadius.x, cornerCenter[i].y + SDL_sinf(angle1) * signedRadius.y}, color, {0, 0} };
+            vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[i].x + SDL_cosf(angle2) * signedRadius.x, cornerCenter[i].y + SDL_sinf(angle2) * signedRadius.y}, color, {0, 0} };
+
+            indices[indexCount++] = 4 + i;  // Connect to corresponding corner center
             indices[indexCount++] = vertexCount - 2;
             indices[indexCount++] = vertexCount - 1;
         }
@@ -103,48 +138,41 @@ static void SDL_RenderFillRoundedRect(SDL_Renderer* renderer, const SDL_FRect re
 
     //Define edge rectangles
     // Top edge
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + clampedRadius, rect.y}, color, {0, 0} }; //TL
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w - clampedRadius, rect.y}, color, {1, 0} }; //TR
+    for (int i = 0; i < 6; i++)
+        indices[indexCount++] = vertexCount + rectIndices[i];
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[TOP_LEFT].x, rect.y}, color, {0, 0} }; //TL
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[TOP_RIGHT].x, rect.y}, color, {1, 0} }; //TR
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[TOP_RIGHT].x, innerTop}, color, {1, 0} }; //BR
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[TOP_LEFT].x, innerTop}, color, {0, 0} }; //BL
 
-    indices[indexCount++] = 0;
-    indices[indexCount++] = vertexCount - 2; //TL
-    indices[indexCount++] = vertexCount - 1; //TR
-    indices[indexCount++] = 1;
-    indices[indexCount++] = 0;
-    indices[indexCount++] = vertexCount - 1; //TR
     // Right edge
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w, rect.y + clampedRadius}, color, {1, 0} }; //RT
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w, rect.y + rect.h - clampedRadius}, color, {1, 1} }; //RB
+    for (int i = 0; i < 6; i++)
+        indices[indexCount++] = vertexCount + rectIndices[i];
+    vertices[vertexCount++] = (SDL_Vertex){ {innerRight, cornerCenter[TOP_RIGHT].y}, color, {1, 0} }; //TL
+    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w, cornerCenter[TOP_RIGHT].y}, color, {1, 0} }; //TR
+    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w, cornerCenter[BOTTOM_RIGHT].y}, color, {1, 1} }; //BR
+    vertices[vertexCount++] = (SDL_Vertex){ {innerRight, cornerCenter[BOTTOM_RIGHT].y}, color, {1, 1} }; //BL
 
-    indices[indexCount++] = 1;
-    indices[indexCount++] = vertexCount - 2; //RT
-    indices[indexCount++] = vertexCount - 1; //RB
-    indices[indexCount++] = 2;
-    indices[indexCount++] = 1;
-    indices[indexCount++] = vertexCount - 1; //RB
     // Bottom edge
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + rect.w - clampedRadius, rect.y + rect.h}, color, {1, 1} }; //BR
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x + clampedRadius, rect.y + rect.h}, color, {0, 1} }; //BL
+    for (int i = 0; i < 6; i++)
+        indices[indexCount++] = vertexCount + rectIndices[i];
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[BOTTOM_LEFT].x, innerBottom}, color, {0, 1} }; //BL
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[BOTTOM_RIGHT].x, innerBottom}, color, {1, 1} }; //BR
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[BOTTOM_RIGHT].x, rect.y + rect.h}, color, {1, 1} }; //BR
+    vertices[vertexCount++] = (SDL_Vertex){ {cornerCenter[BOTTOM_LEFT].x, rect.y + rect.h}, color, {0, 1} }; //BL
 
-    indices[indexCount++] = 2;
-    indices[indexCount++] = vertexCount - 2; //BR
-    indices[indexCount++] = vertexCount - 1; //BL
-    indices[indexCount++] = 3;
-    indices[indexCount++] = 2;
-    indices[indexCount++] = vertexCount - 1; //BL
     // Left edge
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x, rect.y + rect.h - clampedRadius}, color, {0, 1} }; //LB
-    vertices[vertexCount++] = (SDL_Vertex){ {rect.x, rect.y + clampedRadius}, color, {0, 0} }; //LT
-
-    indices[indexCount++] = 3;
-    indices[indexCount++] = vertexCount - 2; //LB
-    indices[indexCount++] = vertexCount - 1; //LT
-    indices[indexCount++] = 0;
-    indices[indexCount++] = 3;
-    indices[indexCount++] = vertexCount - 1; //LT
+    for (int i = 0; i < 6; i++)
+        indices[indexCount++] = vertexCount + rectIndices[i];
+    vertices[vertexCount++] = (SDL_Vertex){ {rect.x, cornerCenter[TOP_LEFT].y}, color, {0, 1} }; //LB
+    vertices[vertexCount++] = (SDL_Vertex){ {innerLeft, cornerCenter[TOP_LEFT].y}, color, {0, 0} }; //LT
+    vertices[vertexCount++] = (SDL_Vertex){ {innerLeft, cornerCenter[BOTTOM_LEFT].y}, color, {0, 1} }; //LB
+    vertices[vertexCount++] = (SDL_Vertex){ {rect.x, cornerCenter[BOTTOM_LEFT].y}, color, {0, 0} }; //LT
 
     // Render everything
     SDL_RenderGeometry(renderer, NULL, vertices, vertexCount, indices, indexCount);
+    SDL_free(vertices);
+    SDL_free(indices);
 }
 
 //all rendering is performed by a single SDL call, using twi sets of arcing triangles, inner and outer, that fit together; along with two tringles to fill the end gaps.
@@ -282,8 +310,8 @@ static void Clay_SDL2_Render(SDL_Renderer *renderer, Clay_RenderCommandArray ren
                         .w = boundingBox.width,
                         .h = boundingBox.height,
                 };
-                if (config->cornerRadius.topLeft > 0) {
-                    SDL_RenderFillRoundedRect(renderer, rect, config->cornerRadius.topLeft, color);
+                if (config->cornerRadius.topLeft > 1.f || config->cornerRadius.topRight > 1.f || config->cornerRadius.bottomLeft > 1.f || config->cornerRadius.bottomRight > 1.f) {
+                    SDL_RenderFillRoundedRect(renderer, rect, config->cornerRadius, color);
                 }
                 else {
                     SDL_RenderFillRectF(renderer, &rect);


### PR DESCRIPTION
This pull request adds rendering of separate radius for each corner of a RoundedRectangle for SDL2 and SDL3.
The radius of each corner is still limited by the half of the min(rect.w, rect.h) until this part of the layout is handled by clay.

```
    CLAY({ .id = CLAY_ID("OuterContainer"),
        .backgroundColor = {43, 41, 51, 255 },
        .layout = {
            .layoutDirection = CLAY_TOP_TO_BOTTOM,
            .sizing = layoutExpand,
            .padding = CLAY_PADDING_ALL(16),
            .childGap = 16
        }
    }) {
        RenderSquare(CLAY_CORNER_RADIUS(8));
        RenderSquare((Clay_CornerRadius){ 16.f, 0.f, 0.f, 0.f });
        RenderSquare((Clay_CornerRadius){ 0.f, 16.f, 0.f, 0.f });
        RenderSquare((Clay_CornerRadius){ 0.f, 0.f,16.f, 0.f });
        RenderSquare((Clay_CornerRadius){ 0.f, 0.f,0.f,16.f });
        RenderSquare((Clay_CornerRadius){ 0.f, 0.f,RECTANGLE_HEIGHT, 0.f });
        RenderSquare((Clay_CornerRadius){ RECTANGLE_HEIGHT, 10.f,20.f,0.f });
    }
```

<img width="807" height="644" alt="image" src="https://github.com/user-attachments/assets/a7f9c323-126f-4a01-8055-5d62114bd58b" />
