### PR TITLE
[Renderers/termbox] fixed horizontal text culling bug

### DIFF
--- a/examples/termbox2-demo/CMakeLists.txt
+++ b/examples/termbox2-demo/CMakeLists.txt
@@ -8,7 +8,7 @@ set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(
     termbox2
     GIT_REPOSITORY "https://github.com/termbox/termbox2.git"
-    GIT_TAG "9c9281a9a4c971a2be57f8645e828ec99fd555e8"
+    GIT_TAG "ffd159c2a6106dd5eef338a6702ad15d4d4aa809"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )
@@ -17,7 +17,7 @@ FetchContent_MakeAvailable(termbox2)
 FetchContent_Declare(
     stb
     GIT_REPOSITORY "https://github.com/nothings/stb.git"
-    GIT_TAG "f58f558c120e9b32c217290b80bad1a0729fbb2c"
+    GIT_TAG "fede005abaf93d9d7f3a679d1999b2db341b360f"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )

--- a/examples/termbox2-demo/main.c
+++ b/examples/termbox2-demo/main.c
@@ -90,7 +90,7 @@ void component_text_pair(const char *key, const char *value)
 
 void component_termbox_settings(void)
 {
-    CLAY_AUTO_ID({
+    CLAY(CLAY_ID("Termbox Settings"), {
         .floating = {
             .attachTo = CLAY_ATTACH_TO_PARENT,
             .zIndex = 1,

--- a/examples/termbox2-demo/main.c
+++ b/examples/termbox2-demo/main.c
@@ -509,13 +509,18 @@ Clay_RenderCommandArray CreateLayout(clay_tb_image *image1, clay_tb_image *image
 {
     Clay_BeginLayout();
     CLAY_AUTO_ID({
+        .clip = {
+            .vertical = false,
+            .horizontal = true,
+            .childOffset = Clay_GetScrollOffset(),
+        },
         .layout = {
             .sizing = {
                 .width = CLAY_SIZING_GROW(),
                 .height = CLAY_SIZING_GROW()
             },
             .childAlignment = {
-                .x = CLAY_ALIGN_X_CENTER,
+                .x = CLAY_ALIGN_X_LEFT,
                 .y = CLAY_ALIGN_Y_CENTER
             },
             .childGap = 64
@@ -714,12 +719,12 @@ void handle_termbox_events(void)
                             break;
                         }
                         case TB_KEY_MOUSE_WHEEL_UP: {
-                            Clay_Vector2 scrollDelta = { 0, 1 * Clay_Termbox_Cell_Height() };
+                            Clay_Vector2 scrollDelta = { 0.5 * Clay_Termbox_Cell_Width(), 0 };
                             Clay_UpdateScrollContainers(false, scrollDelta, 1);
                             break;
                         }
                         case TB_KEY_MOUSE_WHEEL_DOWN: {
-                            Clay_Vector2 scrollDelta = { 0, -1 * Clay_Termbox_Cell_Height() };
+                            Clay_Vector2 scrollDelta = { -0.5 * Clay_Termbox_Cell_Width(), 0 };
                             Clay_UpdateScrollContainers(false, scrollDelta, 1);
                             break;
                         }

--- a/renderers/termbox2/clay_renderer_termbox2.c
+++ b/renderers/termbox2/clay_renderer_termbox2.c
@@ -1616,6 +1616,20 @@ void Clay_Termbox_Render(Clay_RenderCommandArray commands)
 
                 Clay_StringSlice *text = &render_data.stringContents;
                 int32_t i = 0;
+
+                // culling text characters that are outside of the layout
+                int h_clip = 0 - cell_box.x;
+                while(h_clip > 0 && i < text->length){
+                    uint32_t ch = ' ';
+                    int codepoint_length = tb_utf8_char_to_unicode(&ch, text->chars + i);
+                    if (0 > codepoint_length) {
+                        clay_tb_assert(false, "Invalid utf8");
+                    }
+                    i += codepoint_length;
+                    h_clip -= 1;
+                }
+
+                // printing the rest of the characters
                 for (int y = box_begin_y; y < box_end_y; ++y) {
                     for (int x = box_begin_x; x < box_end_x;) {
                         uint32_t ch = ' ';

--- a/renderers/termbox2/clay_renderer_termbox2.c
+++ b/renderers/termbox2/clay_renderer_termbox2.c
@@ -3,6 +3,8 @@
 
     Copyright (c) 2025 Mivirl
 
+    altered by Godje (Sep 2025)
+
     This software is provided 'as-is', without any express or implied warranty.
     In no event will the authors be held liable for any damages arising from the
     use of this software.


### PR DESCRIPTION
##### note to Maintainer
This branch includes the code from PR #523 . If this merges first, the other #523  can be closed.

# Bug (before)
Incorrect trimming behavior appears when the text's `boundingBox.x` coordinate starts going below negative numbers. Instead of culling the text from the left, it trims it from the right.

## Visual demonstration of the bug
### Before scrolling

<img width="556" height="400" alt="image" src="https://github.com/user-attachments/assets/048efb71-9e6a-4d52-8acf-dc1b83c31b7e" />

### After scrolling

<img width="459" height="400" alt="image" src="https://github.com/user-attachments/assets/488b511e-b7e7-4014-83dc-15cec4f181a4" />

# Fix (after)
Added a small loop before the main text rendering loop that increments the "text printed counter" (`i`) without actually printing the text, which then makes the main renderer loop start from the correct character when printing.

## Visual demonstration of the fix
### Before scrolling

<img width="454.39229" height="400" alt="image" src="https://github.com/user-attachments/assets/33f0798e-fafc-4df9-883b-7148bea78d09" />

### After scrolling
<img width="442.2301" height="400" alt="image" src="https://github.com/user-attachments/assets/ae33a1e3-168e-4968-9bd5-b765ceb5646d" />

