### PR TITLE
[bindings/odin] allows clay to statically dispatch based on const

### DIFF
--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -439,7 +439,12 @@ UI_AutoId :: proc() -> proc (config: ElementDeclaration) -> bool {
 
 UI :: proc{UI_WithId, UI_AutoId};
 
-Text :: proc($text: string, config: ^TextElementConfig) {
+Text :: proc {
+	TextStatic,
+	TextDynamic,
+}
+
+TextStatic :: proc($text: string, config: ^TextElementConfig) {
 	wrapped := MakeString(text)
 	wrapped.isStaticallyAllocated = true
 	_OpenTextElement(wrapped, config)


### PR DESCRIPTION
the limitation not allowing use of `Text` for both static and dynamic variants has been resolved in <https://github.com/odin-lang/Odin/releases/tag/dev-2025-09> with the following fix:
- Skip errors on polymorphic procs when in a proc group with other options

this addresses that by making `TextStatic` and `TextDynamic` into a proc group of the name `Text`. this is not a breaking change