### PR TITLE
Fixed incorrect assignment in README example

### DIFF
--- a/bindings/odin/README.md
+++ b/bindings/odin/README.md
@@ -21,7 +21,7 @@ CLAY({ .id = CLAY_ID("Outer"), .layout = { .padding = CLAY_PADDING_ALL(16) } }) 
 
 ```Odin
 // Odin form of element macros
-if clay.UI()({ id = clay.ID("Outer"), layout = { padding = clay.PaddingAll(16) }}) {
+if clay.UI(clay.ID("Outer"))({ layout = { padding = clay.PaddingAll(16) }}) {
     // Child elements here
 }
 ```


### PR DESCRIPTION
Just noticed that the README and the example differ in how you assign an id to a clay.UI in the Odin bindings.