### PR TITLE
[Renderers/SDL3] Remove unused includes

### DIFF
--- a/examples/SDL3-simple-demo/main.c
+++ b/examples/SDL3-simple-demo/main.c
@@ -2,6 +2,7 @@
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL.h>
 #include <SDL3_ttf/SDL_ttf.h>
+#include <SDL3_image/SDL_image.h>
 
 #define CLAY_IMPLEMENTATION
 #include "../../clay.h"

--- a/renderers/SDL3/clay_renderer_SDL3.c
+++ b/renderers/SDL3/clay_renderer_SDL3.c
@@ -1,7 +1,6 @@
 #include "../../clay.h"
 #include <SDL3/SDL.h>
 #include <SDL3_ttf/SDL_ttf.h>
-#include <SDL3_image/SDL_image.h>
 
 typedef struct {
     SDL_Renderer *renderer;


### PR DESCRIPTION
The "SDL3/SDL_main.h" header should only be included with the application entry point, which a renderer probably shouldn't include. In my setup, when included with the renderer, I get an error similar to:
```
Undefined symbols for architecture arm64:
  "_main", referenced from:
      <initial-undefines>
ld: symbol(s) not found for architecture arm64
```
Simply removing it makes the error go away, and I can't find it being used anywhere either.

The "SDL3_image/SDL_image.h" header also forces any application that uses the renderer to include SDL_image, which isn't even being used from the renderer. However, it is used in the example, so I feel like it makes more sense to have it there instead.

Thank you! ☺️ 