### PR TITLE
fix: address hash overflow risk while reserving 0

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -53,6 +53,7 @@
 
 #define CLAY__MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define CLAY__MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define CLAY__INC_IF_ZERO(h) (h + (h == 0))
 
 #define CLAY_TEXT_CONFIG(...) Clay__StoreTextElementConfig(CLAY__CONFIG_WRAPPER(Clay_TextElementConfig, __VA_ARGS__))
 
@@ -1365,7 +1366,7 @@ Clay_ElementId Clay__HashNumber(const uint32_t offset, const uint32_t seed) {
     hash += (hash << 3);
     hash ^= (hash >> 11);
     hash += (hash << 15);
-    return CLAY__INIT(Clay_ElementId) { .id = hash + 1, .offset = offset, .baseId = seed, .stringId = CLAY__STRING_DEFAULT }; // Reserve the hash result of zero as "null id"
+    return CLAY__INIT(Clay_ElementId) { .id = CLAY__INC_IF_ZERO(hash), .offset = offset, .baseId = seed, .stringId = CLAY__STRING_DEFAULT }; // Reserve the hash result of zero as "null id"
 }
 
 Clay_ElementId Clay__HashString(Clay_String key, const uint32_t seed) {
@@ -1380,7 +1381,7 @@ Clay_ElementId Clay__HashString(Clay_String key, const uint32_t seed) {
     hash += (hash << 3);
     hash ^= (hash >> 11);
     hash += (hash << 15);
-    return CLAY__INIT(Clay_ElementId) { .id = hash + 1, .offset = 0, .baseId = hash + 1, .stringId = key }; // Reserve the hash result of zero as "null id"
+    return CLAY__INIT(Clay_ElementId) { .id = CLAY__INC_IF_ZERO(hash), .offset = 0, .baseId = CLAY__INC_IF_ZERO(hash), .stringId = key }; // Reserve the hash result of zero as "null id"
 }
 
 Clay_ElementId Clay__HashStringWithOffset(Clay_String key, const uint32_t offset, const uint32_t seed) {
@@ -1403,7 +1404,7 @@ Clay_ElementId Clay__HashStringWithOffset(Clay_String key, const uint32_t offset
     base ^= (base >> 11);
     hash += (hash << 15);
     base += (base << 15);
-    return CLAY__INIT(Clay_ElementId) { .id = hash + 1, .offset = offset, .baseId = base + 1, .stringId = key }; // Reserve the hash result of zero as "null id"
+    return CLAY__INIT(Clay_ElementId) { .id = CLAY__INC_IF_ZERO(hash), .offset = offset, .baseId = base + 1, .stringId = key }; // Reserve the hash result of zero as "null id"
 }
 
 #if !defined(CLAY_DISABLE_SIMD) && (defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64))
@@ -1554,7 +1555,7 @@ uint32_t Clay__HashStringContentsWithConfig(Clay_String *text, Clay_TextElementC
     hash += (hash << 3);
     hash ^= (hash >> 11);
     hash += (hash << 15);
-    return hash + 1; // Reserve the hash result of zero as "null id"
+    return CLAY__INC_IF_ZERO(hash); // Reserve the hash result of zero as "null id"
 }
 
 Clay__MeasuredWord *Clay__AddMeasuredWord(Clay__MeasuredWord word, Clay__MeasuredWord *previousWord) {


### PR DESCRIPTION
# Summary
There is a risk that the hash value would overflow back to 0, this is a non-branching option that still reserves 0. It does change the hash value used in most cases (most are no longer incremented). I am extremely new to the codebase so I don't have any idea whether changing the hashing function is likely to break existing consumers (I certainly hope no one depends on it), but please
correct me if that is a bad assumption.

# Validation
As far as testing goes, I have run `cmake .` followed by `make` locally and confirmed everything builds with no new warnings. The only existing warning is:
```
[  0%] Building C object examples/clay-official-website/CMakeFiles/clay_official_website.dir/main.c.o
~/dev/clay/examples/clay-official-website/main.c: In function ‘HandleRendererButtonInteraction’:
~/dev/clay/examples/clay-official-website/main.c:237:33: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  237 |         ACTIVE_RENDERER_INDEX = (uint32_t)userData;
      |                                 ^
```
As a low effort sanity check, I have also run `./examples/terminal-example/clay_examples_terminal` with and without the change to see that there are no obvious differences.
Please provide guidance if there is some test command I can/should be running, I didn't see any but I don't normally use `cmake` so it is likely I missed something.

# Issue(s)
https://github.com/nicbarker/clay/issues/556