### PR TITLE
fix: remove duplicate context->layoutDimensions init

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4064,7 +4064,6 @@ Clay_Context* Clay_Initialize(Clay_Arena arena, Clay_Dimensions layoutDimensions
         context->measureTextHashMap.internalArray[i] = 0;
     }
     context->measureTextHashMapInternal.length = 1; // Reserve the 0 value to mean "no next element"
-    context->layoutDimensions = layoutDimensions;
     return context;
 }
 


### PR DESCRIPTION
# Summary
Removing a redundant property initialization, `layoutDimensions` was already set to the same value on line 4054.

# Validation
I have run `cmake .` followed by `make` locally and confirmed everything builds with no new warnings. The only existing warning is:
```
[  0%] Building C object examples/clay-official-website/CMakeFiles/clay_official_website.dir/main.c.o
~/dev/clay/examples/clay-official-website/main.c: In function ‘HandleRendererButtonInteraction’:
~/dev/clay/examples/clay-official-website/main.c:237:33: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  237 |         ACTIVE_RENDERER_INDEX = (uint32_t)userData;
      |                                 ^
```
As a low effort sanity check, I have also run `./examples/terminal-example/clay_examples_terminal` with and without the change to see that there are no obvious differences.
Please provide guidance if there is some test command I can/should be running, I didn't see any but I don't normally use `cmake` so it is likely I missed something.