### PR TITLE
Feat(raylib renderer): Make utf8 work with raylib renderer

### DIFF
--- a/renderers/raylib/clay_renderer_raylib.c
+++ b/renderers/raylib/clay_renderer_raylib.c
@@ -125,7 +125,7 @@ static inline Clay_Raylib_GlyphCodename Raylib_MeasureUtf8Glyph (Clay_StringSlic
 }
 
 
-Clay_Dimensions Raylib_MeasureText(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData) {
+static inline Clay_Dimensions Raylib_MeasureText(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData) {
     // Measure string size for Font
     Clay_Dimensions textSize = { 0 };
 


### PR DESCRIPTION
Main problem was that firstly utf8 in raylib is been drawn in char* format
e.g cyrillic н is been represented as [208, 189] ([Wiki](https://en.wikipedia.org/wiki/UTF-8 ) - check 'Description' part)

# So in short terms
1. 208 (first number of h) - would overflow and be saved as -48
2. 
```
int index = text.chars[i] - 32
int index = -48 - 32
int index = -80
```
3. Then it would cause out of bounds access
`fontToUse.glyphs[index]`

# The second issue was that 
`int index = text.chars[i] - 32`
Reads only one char, while to decode utf-8 we need to read several of them

# Third
Also added check on index to prevent out of bounds (if not all glyphs are loaded)
```
if (index < 0 || index >= fontToUse.glyphCount) {
    continue;                                       // skip characters not in the font
}
```