### PR TITLE
Add java implementation of Clay to bindings folder

### DIFF
--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,0 +1,1 @@
+https://github.com/Lauriichan/clay4j


### PR DESCRIPTION
I made a reimplementation of Clay in Java, its not great by any means but it works (for the most part)
It might help someone so I thought maybe it could be added to the bindings folder :)