### PR TITLE
Add Java rewrite to the 'Other implementations' section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Clay has also been implemented in other languages:
 - [`glay`](https://github.com/soypat/glay) - Go line-by-line rewrite with readability as main goal.
 - [`totallygamerjet/clay`](https://github.com/totallygamerjet/clay) - Port using `cxgo`, a C to Go transpiler.
 - [`goclay`](https://github.com/igadmg/goclay) - Go line-by-line rewrite closely matching the reference.
+- [`clay4j`](https://github.com/Lauriichan/clay4j) - A Java rewrite covering most features.
 
 ### Debug Tools
 


### PR DESCRIPTION
I made a reimplementation of Clay in Java, sometimes matching the original C code as closely as possible sometimes not but mostly functional.
I'm not super talented so this might not be the best possible reimplementation there is but so far it seems to be mostly working and I hope others might find it helpful either as a reference for reimplementation of maybe it is of use for them which is why I created this PR.

Note: I made a PR (#574) already but closed it due to this not being a binding so it shouldn't be in the bindings folder instead I made this new PR which made it just be a mention on the main README