### PR TITLE
Fix Issue #471: Access ephemeral data from previous frame through layoutElement pointer in Clay_GetScrollContainerData

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4091,7 +4091,7 @@ Clay_Vector2 Clay_GetScrollOffset(void) {
     }
     for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
         Clay__ScrollContainerDataInternal *mapping = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
-        if (mapping->layoutElement == openLayoutElement) {
+        if (mapping->elementId == openLayoutElement->id) {
             return mapping->scrollPosition;
         }
     }


### PR DESCRIPTION
The relevant context is in issue #471, the fix proposed by @dhanton is now possible with the new way IDs are assigned to Clay elements.