### PR TITLE
fix(#581): update pointer state every frame in SDL3 simple demo

### DIFF
--- a/examples/SDL3-simple-demo/main.c
+++ b/examples/SDL3-simple-demo/main.c
@@ -157,14 +157,6 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
         case SDL_EVENT_WINDOW_RESIZED:
             Clay_SetLayoutDimensions((Clay_Dimensions) { (float) event->window.data1, (float) event->window.data2 });
             break;
-        case SDL_EVENT_MOUSE_MOTION:
-            Clay_SetPointerState((Clay_Vector2) { event->motion.x, event->motion.y },
-                                 event->motion.state & SDL_BUTTON_LMASK);
-            break;
-        case SDL_EVENT_MOUSE_BUTTON_DOWN:
-            Clay_SetPointerState((Clay_Vector2) { event->button.x, event->button.y },
-                                 event->button.button == SDL_BUTTON_LEFT);
-            break;
         case SDL_EVENT_MOUSE_WHEEL:
             Clay_UpdateScrollContainers(true, (Clay_Vector2) { event->wheel.x, event->wheel.y }, 0.01f);
             break;
@@ -178,6 +170,15 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 SDL_AppResult SDL_AppIterate(void *appstate)
 {
     AppState *state = appstate;
+
+    float mouse_x, mouse_y;
+
+    Uint32 buttons = SDL_GetMouseState(&mouse_x, &mouse_y);
+
+    Clay_SetPointerState(
+        (Clay_Vector2){.x = mouse_x, .y = mouse_y},
+        buttons & SDL_BUTTON_LMASK
+    );
 
     Clay_RenderCommandArray render_commands = (show_demo
         ? ClayVideoDemo_CreateLayout(&state->demoData)
@@ -228,5 +229,6 @@ void SDL_AppQuit(void *appstate, SDL_AppResult result)
 
         SDL_free(state);
     }
+
     TTF_Quit();
 }


### PR DESCRIPTION
Fixes #581.

https://github.com/user-attachments/assets/9ac6b915-07a2-41cf-8329-0bde38edbeb5

Context:
> > It's not just the example, it's the renderer (`clay_renderer_SDL3.c`) itself. My application is exhibiting the same issue. Mouse click events are not handled until the mouse subsequently moves. It is making for a very frustrating experience. I was hoping to not have to modify the out-of-box renderer, as I have little knowledge regarding C, SDL, and Clay's internals, so I have yet to try diagnosing the root cause.
> 
> Update: mea culpa. I just assumed the demo application would be properly written to provide a valid base for people to build projects off of. The renderer seems fine, the problem is that the demo application does not respect the following (from the docs):
> 
> [README.md, L557-L558](https://github.com/nicbarker/clay/blob/76ec3632d80c145158136fd44db501448e7b17c4/README.md?plain=1#L557-L558)
> 
> ---
> 
> ### Lifecycle for public functions
> 
> . . .
> 
> **Each Frame**
> `Clay_SetLayoutDimensions` -> `Clay_SetPointerState` -> `Clay_UpdateScrollContainers` -> `Clay_BeginLayout` -> `CLAY() etc...` -> `Clay_EndLayout`
> 
> ---
> 
> Instead of updating the pointer state each frame before rendering, the demo application only updates the pointer state in response to events from SDL:
> 
> [examples/SDL3-simple-demo/main.c, L160-L167](https://github.com/nicbarker/clay/blob/76ec3632d80c145158136fd44db501448e7b17c4/examples/SDL3-simple-demo/main.c#L160-L167)
> 
> ```c
> SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
> {
> 
> ...
> 
>     switch (event->type) {
> 
> ...
> 
>         case SDL_EVENT_MOUSE_MOTION:
>             Clay_SetPointerState((Clay_Vector2) { event->motion.x, event->motion.y },
>                                  event->motion.state & SDL_BUTTON_LMASK);
>             break;
>         case SDL_EVENT_MOUSE_BUTTON_DOWN:
>             Clay_SetPointerState((Clay_Vector2) { event->button.x, event->button.y },
>                                  event->button.button == SDL_BUTTON_LEFT);
>             break;
> 
> ...
> ```
> 
> The fix, I believe, is the following:
> 
> ```diff
>         case SDL_EVENT_WINDOW_RESIZED:
>             Clay_SetLayoutDimensions((Clay_Dimensions) { (float) event->window.data1, (float) event->window.data2 });
>             break;
> -        case SDL_EVENT_MOUSE_MOTION:
> -            Clay_SetPointerState((Clay_Vector2) { event->motion.x, event->motion.y },
> -                                 event->motion.state & SDL_BUTTON_LMASK);
> -            break;
> -        case SDL_EVENT_MOUSE_BUTTON_DOWN:
> -            Clay_SetPointerState((Clay_Vector2) { event->button.x, event->button.y },
> -                                 event->button.button == SDL_BUTTON_LEFT);
> -            break;
>         case SDL_EVENT_MOUSE_WHEEL:
> ```
> 
> ```diff
> SDL_AppResult SDL_AppIterate(void *appstate)
> {
>     AppState *state = appstate;
> +
> +  float mouse_x, mouse_y;
> +
> +  Uint32 buttons = SDL_GetMouseState(&mouse_x, &mouse_y);
> +
> +  Clay_SetPointerState(
> +    (Clay_Vector2){.x = mouse_x, .y = mouse_y},
> +    (buttons & SDL_BUTTON_LMASK));
> +
>     Clay_RenderCommandArray render_commands = (show_demo
>         ? ClayVideoDemo_CreateLayout(&state->demoData)
>         : ClayImageSample_CreateLayout()
>     );
> ```
> 
> I will open a PR. 

 _Originally posted by @euphemism in [#581](https://github.com/nicbarker/clay/issues/581#issuecomment-4130790341)_