### PR TITLE
Fix pointer state update order in Clay_SetPointerState hover dispatch

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -3974,6 +3974,19 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
     }
     context->pointerInfo.position = position;
     context->pointerOverIds.length = 0;
+    if (isPointerDown) {
+        if (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
+            context->pointerInfo.state = CLAY_POINTER_DATA_PRESSED;
+        } else if (context->pointerInfo.state != CLAY_POINTER_DATA_PRESSED) {
+            context->pointerInfo.state = CLAY_POINTER_DATA_PRESSED_THIS_FRAME;
+        }
+    } else {
+        if (context->pointerInfo.state == CLAY_POINTER_DATA_RELEASED_THIS_FRAME) {
+            context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED;
+        } else if (context->pointerInfo.state != CLAY_POINTER_DATA_RELEASED)  {
+            context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED_THIS_FRAME;
+        }
+    }	
     Clay__int32_tArray dfsBuffer = context->layoutElementChildrenBuffer;
     for (int32_t rootIndex = context->layoutElementTreeRoots.length - 1; rootIndex >= 0; --rootIndex) {
         dfsBuffer.length = 0;
@@ -4022,19 +4035,6 @@ void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
         }
     }
 
-    if (isPointerDown) {
-        if (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
-            context->pointerInfo.state = CLAY_POINTER_DATA_PRESSED;
-        } else if (context->pointerInfo.state != CLAY_POINTER_DATA_PRESSED) {
-            context->pointerInfo.state = CLAY_POINTER_DATA_PRESSED_THIS_FRAME;
-        }
-    } else {
-        if (context->pointerInfo.state == CLAY_POINTER_DATA_RELEASED_THIS_FRAME) {
-            context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED;
-        } else if (context->pointerInfo.state != CLAY_POINTER_DATA_RELEASED)  {
-            context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED_THIS_FRAME;
-        }
-    }
 }
 
 CLAY_WASM_EXPORT("Clay_Initialize")


### PR DESCRIPTION
## Summary

This changes `Clay_SetPointerState` so `context->pointerInfo.state` is updated before ephemeral memory initialization and hover callback traversal.

## Problem

`Clay_OnHover` callbacks can read `pointerInfo.state` to detect click/press events. Previously, callbacks were invoked while `pointerInfo.state` still held the previous frame state; the new state was written only after traversal. This caused handlers that check `CLAY_POINTER_DATA_PRESSED_THIS_FRAME` to miss a first click and react only on a follow-up frame.

## Fix

- Compute `newState` from current state + `isPointerDown`.
- Assign `context->pointerInfo.position` and `context->pointerInfo.state = newState` before `Clay__InitializeEphemeralMemory(context)` and DFS traversal.
- Keep traversal and hover logic unchanged.

## Impact

- Hover/click handlers receive the correct current-frame pointer state during callback execution.
- No API changes.
- No behavior changes outside pointer-state ordering during callback dispatch.

## Notes

This was validated in a WASM app using Clay where button handlers inspect `pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME`.
