### PR TITLE
Fixed warnings by improving ISO C compliance

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -1488,7 +1488,7 @@ uint64_t Clay__HashData(const uint8_t* data, size_t length) {
     __m128i v2 = _mm_set1_epi64x(0x3c6ef372fe94f82bULL);
     __m128i v3 = _mm_set1_epi64x(0xa54ff53a5f1d36f1ULL);
 
-    uint8_t overflowBuffer[16] = { 0 };  // Temporary buffer for small inputs
+    uint8_t overflowBuffer[16] = CLAY__DEFAULT_STRUCT;  // Temporary buffer for small inputs
 
     while (length > 0) {
         __m128i msg;
@@ -1537,7 +1537,7 @@ uint64_t Clay__HashData(const uint8_t* data, size_t length) {
     uint64x2_t v2 = vdupq_n_u64(0x3c6ef372fe94f82bULL);
     uint64x2_t v3 = vdupq_n_u64(0xa54ff53a5f1d36f1ULL);
 
-    uint8_t overflowBuffer[8] = { 0 };
+    uint8_t overflowBuffer[8] = CLAY__DEFAULT_STRUCT;
 
     while (length > 0) {
         uint64x2_t msg;
@@ -2279,6 +2279,7 @@ Clay_SizingAxis Clay__GetElementSizing(Clay_LayoutElement* element, bool xAxis) 
 
 // Writes out the location of text elements to layout elements buffer 1
 void Clay__SizeContainersAlongAxis(bool xAxis, float deltaTime, Clay__int32_tArray* textElementsOut, Clay__int32_tArray* aspectRatioElementsOut) {
+    (void)deltaTime;
     Clay_Context* context = Clay_GetCurrentContext();
     Clay__int32_tArray bfsBuffer = context->layoutElementChildrenBuffer;
     Clay__int32_tArray resizableContainerBuffer = context->openLayoutElementStack;
@@ -3095,7 +3096,7 @@ void Clay__CalculateFinalLayout(float deltaTime, bool useStoredBoundingBoxes, bo
             // Setup positions for child elements and add to DFS buffer ----------
 
             // On-axis alignment
-            Clay_Dimensions contentSizeCurrent = {};
+            Clay_Dimensions contentSizeCurrent = CLAY__DEFAULT_STRUCT;
             if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
                 for (int32_t i = 0; i < currentElement->children.length; ++i) {
                     Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->children.elements[i]);
@@ -3138,7 +3139,6 @@ void Clay__CalculateFinalLayout(float deltaTime, bool useStoredBoundingBoxes, bo
             dfsBuffer.length += currentElement->children.length;
             for (int32_t i = 0; i < currentElement->children.length; ++i) {
                 Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->children.elements[i]);
-                Clay_LayoutElementHashMapItem* childMapItem = Clay__GetHashMapItem(childElement->id);
                 // Alignment along non layout axis
                 if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
                     currentElementTreeNode->nextChildOffset.y = currentElement->config.layout.padding.top;
@@ -3337,7 +3337,7 @@ Clay__RenderDebugLayoutData Clay__RenderDebugLayoutElementsList(int32_t initialR
                     }
                 }
                 if (currentElementData->elementId.stringId.length > 0) {
-                    CLAY_AUTO_ID() {
+                    CLAY_AUTO_ID(0) {
                         Clay_TextElementConfig textConfig = offscreen ? CLAY__INIT(Clay_TextElementConfig) { .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 } : Clay__DebugView_TextNameConfig;
                         CLAY_TEXT(currentElementData->elementId.stringId, textConfig);
                         if (currentElementData->elementId.offset != 0) {
@@ -3474,6 +3474,7 @@ void Clay__RenderDebugLayoutSizing(Clay_SizingAxis sizing, Clay_TextElementConfi
 }
 
 void Clay__DebugViewRenderElementConfigHeader(Clay_String elementId, Clay__DebugElementConfigType type) {
+    (void)elementId;
     Clay__DebugElementConfigTypeLabelConfig config = Clay__DebugGetElementConfigTypeLabel(type);
     Clay_Color backgroundColor = config.color;
     backgroundColor.a = 90;
@@ -3765,7 +3766,7 @@ void Clay__RenderDebugView(void) {
                             Clay__DebugViewRenderElementConfigHeader(selectedItem->elementId.stringId, CLAY__ELEMENT_CONFIG_TYPE_ASPECT);
                             CLAY_TEXT(CLAY_STRING("Aspect Ratio"), infoTitleConfig);
                             // Aspect Ratio
-                            CLAY(CLAY_ID("Clay__DebugViewElementInfoAspectRatio"), { }) {
+                            CLAY(CLAY_ID("Clay__DebugViewElementInfoAspectRatio"), CLAY__DEFAULT_STRUCT) {
                                 CLAY_TEXT(Clay__IntToString(aspectRatioConfig->aspectRatio), infoTextConfig);
                                 CLAY_TEXT(CLAY_STRING("."), infoTextConfig);
                                 float frac = aspectRatioConfig->aspectRatio - (int)(aspectRatioConfig->aspectRatio);
@@ -4075,7 +4076,7 @@ void Clay_SetLayoutDimensions(Clay_Dimensions dimensions) {
 }
 
 CLAY_WASM_EXPORT("Clay_SetLayoutDimensions")
-Clay_Dimensions Clay_GetLayoutDimensions() {
+Clay_Dimensions Clay_GetLayoutDimensions(void) {
     Clay_Context* context = Clay_GetCurrentContext();
     return context->layoutDimensions;
 }
@@ -4371,14 +4372,13 @@ void Clay_BeginLayout(void) {
     Clay__LayoutElementTreeRootArray_Add(&context->layoutElementTreeRoots, CLAY__INIT(Clay__LayoutElementTreeRoot) { .layoutElementIndex = 0 });
 }
 
-void Clay__CloneElementsWithExitTransition() {
+void Clay__CloneElementsWithExitTransition(void) {
     Clay_Context* context = Clay_GetCurrentContext();
     int32_t nextIndex = context->layoutElements.capacity - 1;
     int32_t nextChildIndex = context->layoutElementChildren.capacity - 1;
 
     for (int i = 0; i < context->transitionDatas.length; ++i) {
         Clay__TransitionDataInternal *data = Clay__TransitionDataInternalArray_Get(&context->transitionDatas, i);
-        Clay_TransitionElementConfig* config = &data->elementThisFrame->config.transition;
         if (data->transitionOut) {
             Clay__int32_tArray bfsBuffer = context->openLayoutElementStack;
             bfsBuffer.length = 0;
@@ -4395,7 +4395,6 @@ void Clay__CloneElementsWithExitTransition() {
                 for (int j = layoutElement->children.length - 1; j >= 0; --j) {
                     Clay_LayoutElement* childElement = Clay_LayoutElementArray_GetCheckCapacity(&context->layoutElements, layoutElement->children.elements[j]);
                     Clay__int32_tArray_Add(&bfsBuffer, nextIndex);
-                    Clay_LayoutElement* newChildElement = Clay_LayoutElementArray_Set_DontTouchLength(&context->layoutElements, nextIndex, *childElement);
                     Clay__StringArray_Set_DontTouchLength(&context->layoutElementIdStrings, nextIndex, *Clay__StringArray_GetCheckCapacity(&context->layoutElementIdStrings, childElement - context->layoutElements.internalArray));
                     Clay__int32_tArray_Set_DontTouchLength(&context->layoutElementChildren, nextChildIndex, nextIndex);
                     nextIndex--;
@@ -4405,7 +4404,7 @@ void Clay__CloneElementsWithExitTransition() {
             }
         }
     }
-};
+}
 
 void Clay_ApplyTransitionedPropertiesToElement(Clay_LayoutElement* currentElement, Clay_TransitionProperty properties, Clay_TransitionData currentTransitionData, Clay_BoundingBox* boundingBox, bool reparented) {
     if (properties & CLAY_TRANSITION_PROPERTY_WIDTH) {
@@ -4563,7 +4562,7 @@ Clay_RenderCommandArray Clay_EndLayout(float deltaTime) {
                             found = true;
                         }
                         for (int j = 0; j < parentElement->children.length; ++j) {
-                            if (config->exit.siblingOrdering == CLAY_EXIT_TRANSITION_ORDERING_NATURAL_ORDER && j == data->siblingIndex) {
+                            if (config->exit.siblingOrdering == CLAY_EXIT_TRANSITION_ORDERING_NATURAL_ORDER && (uint32_t)j == data->siblingIndex) {
                                 Clay__int32_tArray_Add(&context->layoutElementChildren, exitingElementIndex);
                                 found = true;
                             }

--- a/renderers/raylib/clay_renderer_raylib.c
+++ b/renderers/raylib/clay_renderer_raylib.c
@@ -232,7 +232,7 @@ void Clay_Raylib_Render(Clay_RenderCommandArray renderCommands, Font* fonts)
                     imageTexture,
                     (Rectangle) { 0, 0, imageTexture.width, imageTexture.height },
                     (Rectangle){boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height},
-                    (Vector2) {},
+                    (Vector2) { 0 },
                     0,
                     CLAY_COLOR_TO_RAYLIB_COLOR(tintColor));
                 break;
@@ -252,6 +252,7 @@ void Clay_Raylib_Render(Clay_RenderCommandArray renderCommands, Font* fonts)
             case CLAY_RENDER_COMMAND_TYPE_OVERLAY_COLOR_END: {
                 DisableColorOverlay();
             }
+            /* fall through */
             case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
                 Clay_RectangleRenderData *config = &renderCommand->renderData.rectangle;
                 if (config->cornerRadius.topLeft > 0) {


### PR DESCRIPTION
This PR fixes the following warnings I get when using Clay+Raylib with GCC 15.2.1 and with `-Wall`, `-Wextra`, and `-pedantic` enabled:

Changes done:
- Replaced initializer braces `{}` and `{ 0 }` with `CLAY__DEFAULT_STRUCT`
- Remove extra trailing semicolon in struct definition
- Cast signed `int` to `uint32_t` in comparison to fix signedness mismatch
- Added `/* fall through */` comment to suppress the implicit case fallthrough warning
- Removed unused variables
- Cast unused parameters to `(void)`

```
clay.h:3071:50: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
 3071 |             Clay_Dimensions contentSizeCurrent = {};
      |                                                  ^

clay.h:160:79: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
  160 | #define CLAY__CONFIG_WRAPPER(type, ...) (CLAY__INIT(CLAY__WRAPPER_TYPE(type)) { __VA_ARGS__ }).wrapped
      |                                                                               ^
clay.h:3313:21: note: in expansion of macro ‘CLAY_AUTO_ID’
 3313 |                     CLAY_AUTO_ID() {
      |                     ^~~~~~~~~~~~

clay.h: In function ‘Clay__RenderDebugView’:
clay.h:3635:72: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
 3635 |                     CLAY(CLAY_ID("Clay__DebugViewElementInfoPadding"), { }) {
      |

clay.h:3739:84: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
 3739 |                             CLAY(CLAY_ID("Clay__DebugViewElementInfoAspectRatio"), { }) {
      |                                                                                    ^

clay.h:4369:2: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 4369 | };
      |  ^

clay.h:4484:114: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
 4484 |                             if (config->exit.siblingOrdering == CLAY_EXIT_TRANSITION_ORDERING_NATURAL_ORDER && j == data->siblingIndex) {
      |

clay_renderer_raylib.c:235:31: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
  235 |                     (Vector2) {},
      |                               ^

clay.h:2257:54: warning: unused parameter ‘deltaTime’ [-Wunused-parameter]
 2257 | void Clay__SizeContainersAlongAxis(bool xAxis, float deltaTime, Clay__int32_tArray* textElementsOut, Clay__int32_tArray* aspectRatioElementsOut) {
      |                                                ~~~~~~^~~~~~~~~

clay.h: In function ‘Clay__CalculateFinalLayout’:
clay.h:3114:48: warning: unused variable ‘childMapItem’ [-Wunused-variable]
 3114 |                 Clay_LayoutElementHashMapItem* childMapItem = Clay__GetHashMapItem(childElement->id);
      |                                                ^~~~~~~~~~~~

clay.h: In function ‘Clay__DebugViewRenderElementConfigHeader’:
clay.h:3449:59: warning: unused parameter ‘elementId’ [-Wunused-parameter]
 3449 | void Clay__DebugViewRenderElementConfigHeader(Clay_String elementId, Clay__DebugElementConfigType type) {
      |                                               ~~~~~~~~~~~~^~~~~~~~~

clay.h: In function ‘Clay__CloneElementsWithExitTransition’:
clay.h:4360:41: warning: unused variable ‘newChildElement’ [-Wunused-variable]
 4360 |                     Clay_LayoutElement* newChildElement = Clay_LayoutElementArray_Set_DontTouchLength(&context->layoutElements, nextIndex, *childElement);
      |                                         ^~~~~~~~~~~~~~~

clay.h:4343:39: warning: unused variable ‘config’ [-Wunused-variable]
 4343 |         Clay_TransitionElementConfig* config = &data->elementThisFrame->config.transition;
      |                                       ^~~~~~

```