### PR TITLE
Add userdata support to transition

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -560,6 +560,7 @@ typedef struct Clay_BorderElementConfig {
 CLAY__WRAPPER_STRUCT(Clay_BorderElementConfig);
 
 typedef struct {
+    void* userData;
     Clay_BoundingBox boundingBox;
     Clay_Color backgroundColor;
     Clay_Color overlayColor;
@@ -624,6 +625,7 @@ typedef CLAY_PACKED_ENUM {
 
 // Controls settings related to transitions
 typedef struct Clay_TransitionElementConfig {
+    void* userData;
     bool (*handler)(Clay_TransitionCallbackArguments arguments);
     float duration;
     Clay_TransitionProperty properties;
@@ -4535,6 +4537,7 @@ Clay_RenderCommandArray Clay_EndLayout(float deltaTime) {
                 Clay_TransitionData targetState = transitionData->targetState;
                 if (transitionData->state != CLAY_TRANSITION_STATE_EXITING) {
                     targetState = CLAY__INIT(Clay_TransitionData) {
+                            currentElement->config.transition.userData,
                             mapItem->boundingBox,
                             currentElement->config.backgroundColor,
                             currentElement->config.overlayColor,


### PR DESCRIPTION
It's relatively simple. The `userData` field in the transition config will be passed as target.
It's up to the user to decide the allocation and lifetime policy.

Personally, I just use arena and it's copied repeatedly during exit: https://github.com/bullno1/bgame/blob/7d11795ec1ddb73fc47f736bc7b4ee51061117a0/src/ui.c#L368-L370

This allows arbitrary customization on the user side.