### PR TITLE
Fix Clay_GetScrollOffset not finding the same element accross frames

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4191,7 +4191,7 @@ Clay_Vector2 Clay_GetScrollOffset(void) {
     Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
     for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
         Clay__ScrollContainerDataInternal *mapping = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
-        if (mapping->layoutElement == openLayoutElement) {
+        if (mapping->elementId == openLayoutElement->id) {
             return mapping->scrollPosition;
         }
     }


### PR DESCRIPTION
If there is a new element between frames, the order of allocation is not the same so pointer comparison doesn't work.
The comparison has to be done with id instead.

This can manifest as a flashing of the scroll container since it will reset to 0 for a single frame.
This can be observed even in the builtin inspector.