### PR TITLE
Links for D bindings

### DIFF
--- a/bindings/d/README
+++ b/bindings/d/README
@@ -1,0 +1,2 @@
+https://github.com/zkxjzmswkwl/clayd
+https://github.com/zkxjzmswkwl/clayui


### PR DESCRIPTION
Added links for D bindings

clayd - is a clay D bindings with the same functionality.
Currently it has only SDL3 renderer. And simple example ready to run (tested on linux and macos)

clayui - is the UI component library, based on clayd. Has raylib and SDL code inside