### PR TITLE
[Examples/termbox2] Fix build for termbox2 demos

### DIFF
--- a/examples/termbox2-demo/CMakeLists.txt
+++ b/examples/termbox2-demo/CMakeLists.txt
@@ -8,7 +8,7 @@ set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(
     termbox2
     GIT_REPOSITORY "https://github.com/termbox/termbox2.git"
-    GIT_TAG "ffd159c2a6106dd5eef338a6702ad15d4d4aa809"
+    GIT_TAG "605398fa79108412976191e062ea14bd4bd30213"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )
@@ -17,7 +17,7 @@ FetchContent_MakeAvailable(termbox2)
 FetchContent_Declare(
     stb
     GIT_REPOSITORY "https://github.com/nothings/stb.git"
-    GIT_TAG "fede005abaf93d9d7f3a679d1999b2db341b360f"
+    GIT_TAG "28d546d5eb77d4585506a20480f4de2e706dff4c"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )

--- a/examples/termbox2-demo/main.c
+++ b/examples/termbox2-demo/main.c
@@ -68,8 +68,7 @@ void component_text_pair(const char *key, const char *value)
         .length = vallen,
         .chars = value,
     };
-    Clay_TextElementConfig *textconfig =
-        CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff } });
+    Clay_TextElementConfig textconfig = { .textColor = { 0xff, 0xff, 0xff, 0xff } };
     CLAY_AUTO_ID({
         .layout = {
             .sizing = {
@@ -306,7 +305,7 @@ void component_color_palette(void)
                                                 CLAY_AUTO_ID({
                                                     .layout = layout,
                                                 }) {
-                                                    CLAY_TEXT(CLAY_STRING("#"), CLAY_TEXT_CONFIG({ .textColor = color }));
+                                                    CLAY_TEXT(CLAY_STRING("#"), { .textColor = color });
                                                 }
                                             }
                                         }
@@ -370,7 +369,7 @@ void component_unicode_text(void)
                 "(from https://stackoverflow.com/a/1644280)\n"
                 " ٩(-̮̮̃-̃)۶ ٩(●̮̮̃•̃)۶ ٩(͡๏̯͡๏)۶ ٩(-̮̮̃•̃)."
             ),
-            CLAY_TEXT_CONFIG({ .textColor = { 0x11, 0x11, 0x11, 0xff } })
+            { .textColor = { 0x11, 0x11, 0x11, 0xff } }
         );
     }
 }
@@ -402,7 +401,7 @@ void component_keybinds(void)
                 "  d/D - Toggle debug mode\n"
                 "  q/Q - Quit\n"
             ),
-            CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff }})
+            { .textColor = { 0xff, 0xff, 0xff, 0xff }}
         );
     }
 }
@@ -482,25 +481,25 @@ void component_bordered_text(void)
             .border = { .width = { 1, 1, 1, 1, 1 }, .color = { 0xaa, 0x00, 0x00, 0xff } },
         }) {
             CLAY_TEXT(
-                CLAY_STRING("Test"), CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff } }));
+                CLAY_STRING("Test"), { .textColor = { 0xff, 0xff, 0xff, 0xff } });
         }
         CLAY_AUTO_ID({
             .border = { .width = { 1, 1, 1, 1, 1 }, .color = { 0x00, 0xaa, 0x00, 0xff } },
         }) {
             CLAY_TEXT(CLAY_STRING("of the border width"),
-                CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff } }));
+                { .textColor = { 0xff, 0xff, 0xff, 0xff } });
         }
         CLAY_AUTO_ID({
             .border = { .width = { 1, 1, 1, 1, 1 }, .color = { 0x00, 0x00, 0xaa, 0xff } },
         }) {
             CLAY_TEXT(CLAY_STRING("and overlap for multiple lines\nof text"),
-                CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff } }));
+                { .textColor = { 0xff, 0xff, 0xff, 0xff } });
         }
         CLAY_AUTO_ID({
             .border = { .width = { 1, 1, 1, 1, 1 }, .color = { 0x00, 0x00, 0xaa, 0xff } },
         }) {
             CLAY_TEXT(CLAY_STRING("this text\nis long enough\nto display all\n borders\naround it"),
-                CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff } }));
+                { .textColor = { 0xff, 0xff, 0xff, 0xff } });
         }
     }
 }
@@ -555,7 +554,7 @@ Clay_RenderCommandArray CreateLayout(clay_tb_image *image1, clay_tb_image *image
 
         component_color_palette();
     }
-    return Clay_EndLayout();
+    return Clay_EndLayout(0);
 }
 
 

--- a/examples/termbox2-image-demo/CMakeLists.txt
+++ b/examples/termbox2-image-demo/CMakeLists.txt
@@ -10,7 +10,7 @@ set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(
     termbox2
     GIT_REPOSITORY "https://github.com/termbox/termbox2.git"
-    GIT_TAG "ffd159c2a6106dd5eef338a6702ad15d4d4aa809"
+    GIT_TAG "605398fa79108412976191e062ea14bd4bd30213"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )
@@ -19,7 +19,7 @@ FetchContent_MakeAvailable(termbox2)
 FetchContent_Declare(
     stb
     GIT_REPOSITORY "https://github.com/nothings/stb.git"
-    GIT_TAG "fede005abaf93d9d7f3a679d1999b2db341b360f"
+    GIT_TAG "28d546d5eb77d4585506a20480f4de2e706dff4c"
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
 )

--- a/examples/termbox2-image-demo/main.c
+++ b/examples/termbox2-image-demo/main.c
@@ -111,8 +111,7 @@ void component_text_pair(const char *key, const char *value)
         .length = vallen,
         .chars = value,
     };
-    Clay_TextElementConfig *textconfig =
-        CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff } });
+    Clay_TextElementConfig textconfig = { .textColor = { 0xff, 0xff, 0xff, 0xff } };
     CLAY_AUTO_ID({
         .layout = {
             .sizing = {
@@ -304,7 +303,7 @@ void component_keybinds(void)
                 "  d/D - Toggle debug mode\n"
                 "  q/Q - Quit\n"
             ),
-            CLAY_TEXT_CONFIG({ .textColor = { 0xff, 0xff, 0xff, 0xff }})
+            { .textColor = { 0xff, 0xff, 0xff, 0xff }}
         );
     }
 }
@@ -446,7 +445,7 @@ Clay_RenderCommandArray CreateLayout(struct img_group **imgs)
         component_image_small(imgs, thumbnail_count, selected_thumbnail);
         component_image(imgs[selected_thumbnail]);
     }
-    return Clay_EndLayout();
+    return Clay_EndLayout(0);
 }
 
 


### PR DESCRIPTION
Update commit hashes for termbox2 and stb to latest. See changes:
- https://github.com/termbox/termbox2/compare/ffd159c2a6106dd5eef338a6702ad15d4d4aa809...605398fa79108412976191e062ea14bd4bd30213
- https://github.com/nothings/stb/compare/fede005abaf93d9d7f3a679d1999b2db341b360f...28d546d5eb77d4585506a20480f4de2e706dff4c

Remove use of `CLAY_TEXT_CONFIG` as it's no longer needed

Adds dummy deltaTime parameter to `Clay_EndLayout`

Fixes build errors from https://github.com/nicbarker/clay/issues/522#issuecomment-4228073675