### PR TITLE
[bindings/odin] fix TransitionProperty values

### DIFF
--- a/bindings/odin/clay-odin/clay.odin
+++ b/bindings/odin/clay-odin/clay.odin
@@ -157,7 +157,6 @@ TransitionState :: enum c.int {
 }
 
 TransitionProperty :: enum c.int {
-	None,
 	X,
 	Y,
 	Width,


### PR DESCRIPTION
Small bug in the bindings that had me scratching my head when trying to animate with `properties = { .Y }`.

Odin assigns the enum values in a bitset starting with 1, so it ends up being:

```odin
TransitionProperty :: enum c.int {
	None, // 1
	X,  // 2
	Y, // 4
	Width, // 8
	Height, // etc
	BackgroundColor,
	OverlayColor,
	CornerRadius,
	BorderColor,
	BorderWidth,
}
```

The properties defined in `clay.h` are:

```c
typedef enum {
    CLAY_TRANSITION_PROPERTY_NONE = 0,
    CLAY_TRANSITION_PROPERTY_X = 1,
    CLAY_TRANSITION_PROPERTY_Y = 2,
    CLAY_TRANSITION_PROPERTY_POSITION = CLAY_TRANSITION_PROPERTY_X | CLAY_TRANSITION_PROPERTY_Y,
    CLAY_TRANSITION_PROPERTY_WIDTH = 4,
    CLAY_TRANSITION_PROPERTY_HEIGHT = 8,
    CLAY_TRANSITION_PROPERTY_DIMENSIONS = CLAY_TRANSITION_PROPERTY_WIDTH | CLAY_TRANSITION_PROPERTY_HEIGHT,
    CLAY_TRANSITION_PROPERTY_BOUNDING_BOX = CLAY_TRANSITION_PROPERTY_POSITION | CLAY_TRANSITION_PROPERTY_DIMENSIONS,
    CLAY_TRANSITION_PROPERTY_BACKGROUND_COLOR = 16,
    CLAY_TRANSITION_PROPERTY_OVERLAY_COLOR = 32,
    CLAY_TRANSITION_PROPERTY_CORNER_RADIUS = 64,
    CLAY_TRANSITION_PROPERTY_BORDER_COLOR = 128,
    CLAY_TRANSITION_PROPERTY_BORDER_WIDTH = 256,
    CLAY_TRANSITION_PROPERTY_BORDER = CLAY_TRANSITION_PROPERTY_BORDER_COLOR | CLAY_TRANSITION_PROPERTY_BORDER_WIDTH
} Clay_TransitionProperty;
```

The `None` value isn't needed as the 0 value of a bit_set is just an empty set (`properties = {}`)