### PR TITLE
[Core] Fix small typo

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4074,7 +4074,7 @@ void Clay_SetLayoutDimensions(Clay_Dimensions dimensions) {
     context->layoutDimensions = dimensions;
 }
 
-CLAY_WASM_EXPORT("Clay_SetLayoutDimensions")
+CLAY_WASM_EXPORT("Clay_GetLayoutDimensions")
 Clay_Dimensions Clay_GetLayoutDimensions() {
     Clay_Context* context = Clay_GetCurrentContext();
     return context->layoutDimensions;


### PR DESCRIPTION
_Seems like this small typo in `clay.h` affecting wasm build with error `parse exception: duplicate export name`_

Changes:
- `CLAY_WASM_EXPORT("Clay_SetLayoutDimensions")` -> `Clay_GetLayoutDimensions`