### PR TITLE
[Core] Fix GetLayoutDimensions WASM_EXPORT

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4074,7 +4074,7 @@ void Clay_SetLayoutDimensions(Clay_Dimensions dimensions) {
     context->layoutDimensions = dimensions;
 }
 
-CLAY_WASM_EXPORT("Clay_SetLayoutDimensions")
+CLAY_WASM_EXPORT("Clay_GetLayoutDimensions")
 Clay_Dimensions Clay_GetLayoutDimensions() {
     Clay_Context* context = Clay_GetCurrentContext();
     return context->layoutDimensions;


### PR DESCRIPTION
Caught when rebasing my copy that also had Clay_GetLayoutDimensions. Didn't want to spam with small PRs unless it's important.