### PR TITLE
fix WASM_EXPORT typo of function Clay_GetLayoutDimensions

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -4074,7 +4074,7 @@ void Clay_SetLayoutDimensions(Clay_Dimensions dimensions) {
     context->layoutDimensions = dimensions;
 }
 
-CLAY_WASM_EXPORT("Clay_SetLayoutDimensions")
+CLAY_WASM_EXPORT("Clay_GetLayoutDimensions")
 Clay_Dimensions Clay_GetLayoutDimensions() {
     Clay_Context* context = Clay_GetCurrentContext();
     return context->layoutDimensions;


### PR DESCRIPTION
While clang didn't complain about this during compilation, the execution of the output .wasm file would break once in the browser :
`Uncaught (in promise) CompileError: wasm validation error: at offset 946: duplicate export`