### PR TITLE
Fix C++20 Playdate compilation error

### DIFF
--- a/renderers/playdate/clay_renderer_playdate.c
+++ b/renderers/playdate/clay_renderer_playdate.c
@@ -165,7 +165,7 @@ static void Clay_Playdate_Render(PlaydateAPI *pd, Clay_RenderCommandArray render
             }
             case CLAY_RENDER_COMMAND_TYPE_IMAGE: {
                 Clay_ImageRenderData *config = &renderCommand->renderData.image;
-                LCDBitmap *texture = config->imageData;
+                LCDBitmap *texture = (LCDBitmap *)config->imageData;
                 int texWidth;
                 int texHeight;
                 pd->graphics->getBitmapData(texture, &texWidth, &texHeight, NULL, NULL, NULL);


### PR DESCRIPTION
clay supports C++20, but when compiling for Playdate with C++20, it actually fails with an error:
```
clay/renderers/playdate/clay_renderer_playdate.c:168:28: error: cannot initialize a variable of type 'LCDBitmap *' with an lvalue of type 'void *'
  168 |                 LCDBitmap *texture = config->imageData;
```

I know it is a tiny fix, but it is the only issue that prevents using clay with C++20 on the Playdate.